### PR TITLE
Refactor byte types and class names to enhance clarity and consistenc…

### DIFF
--- a/include/abc/byte.h
+++ b/include/abc/byte.h
@@ -1,8 +1,8 @@
 // Copyright(c) 2023 - present, Payton Wu (payton.wu@outlook.com) & abc contributors.
 // Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-#if !defined(ABC_BYTE)
-#define ABC_BYTE
+#ifndef ABC_INCLUDE_ABC_BYTE
+#define ABC_INCLUDE_ABC_BYTE
 
 #pragma once
 
@@ -12,8 +12,8 @@
 
 namespace abc {
 
-using byte = std::uint8_t;
+using byte_t = std::uint8_t;
 
 }
 
-#endif
+#endif // ABC_INCLUDE_ABC_BYTE

--- a/include/abc/bytes.h
+++ b/include/abc/bytes.h
@@ -1,8 +1,8 @@
 // Copyright(c) 2023 - present, Payton Wu (payton.wu@outlook.com) & abc contributors.
 // Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-#if !defined(ABC_BYTES)
-#define ABC_BYTES
+#ifndef ABC_INCLUDE_ABC_BASIC_BYTES
+#define ABC_INCLUDE_ABC_BASIC_BYTES
 
 #pragma once
 
@@ -24,7 +24,7 @@ namespace abc
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering RhsByteNumberingV>
     requires(RhsByteNumberingV != ByteNumberingV && RhsByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-constexpr Bytes<ByteNumberingV>::Bytes(Bytes<RhsByteNumberingV> && rhs) : data_{ std::move(rhs.data_) }
+constexpr BasicBytes<ByteNumberingV>::BasicBytes(BasicBytes<RhsByteNumberingV> && rhs) : data_{ std::move(rhs.data_) }
 {
     ranges::reverse(data_);
 }
@@ -32,19 +32,19 @@ constexpr Bytes<ByteNumberingV>::Bytes(Bytes<RhsByteNumberingV> && rhs) : data_{
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering RhsByteNumberingV>
     requires(RhsByteNumberingV != ByteNumberingV && (RhsByteNumberingV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None))
-constexpr Bytes<ByteNumberingV>::Bytes(Bytes<RhsByteNumberingV> && rhs) noexcept : data_{ std::move(rhs.data_) }
+constexpr BasicBytes<ByteNumberingV>::BasicBytes(BasicBytes<RhsByteNumberingV> && rhs) noexcept : data_{ std::move(rhs.data_) }
 {
 }
 
 template <ByteNumbering ByteNumberingV>
-constexpr Bytes<ByteNumberingV>::Bytes(bytes_view<ByteNumberingV> const view) : data_{ std::begin(view), std::end(view) }
+constexpr BasicBytes<ByteNumberingV>::BasicBytes(bytes_view<ByteNumberingV> const view) : data_{ std::begin(view), std::end(view) }
 {
 }
 
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering RhsByteNumberingV>
     requires(RhsByteNumberingV != ByteNumberingV && RhsByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-constexpr Bytes<ByteNumberingV>::Bytes(bytes_view<RhsByteNumberingV> const view) : data_{ std::begin(view), std::end(view) }
+constexpr BasicBytes<ByteNumberingV>::BasicBytes(bytes_view<RhsByteNumberingV> const view) : data_{ std::begin(view), std::end(view) }
 {
     ranges::reverse(data_);
 }
@@ -52,45 +52,47 @@ constexpr Bytes<ByteNumberingV>::Bytes(bytes_view<RhsByteNumberingV> const view)
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering ViewByteNumberingV>
     requires(ViewByteNumberingV != ByteNumberingV && (ViewByteNumberingV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None))
-constexpr Bytes<ByteNumberingV>::Bytes(bytes_view<ViewByteNumberingV> const view) : data_{ std::begin(view), std::end(view) }
+constexpr BasicBytes<ByteNumberingV>::BasicBytes(bytes_view<ViewByteNumberingV> const view) : data_{ std::begin(view), std::end(view) }
 {
 }
 
 template <ByteNumbering ByteNumberingV>
-constexpr Bytes<ByteNumberingV>::Bytes(std::string_view str) requires(ByteNumberingV == ByteNumbering::None) : data_{ str.begin(), str.end() }
+constexpr BasicBytes<ByteNumberingV>::BasicBytes(std::string_view str)
+    requires(ByteNumberingV == ByteNumbering::None)
+    : data_{ str.begin(), str.end() }
 {
 }
 
 template <ByteNumbering ByteNumberingV>
-constexpr Bytes<ByteNumberingV>::Bytes(std::initializer_list<value_type> const il) : data_{ il }
+constexpr BasicBytes<ByteNumberingV>::BasicBytes(std::initializer_list<value_type> const il) : data_{ il }
 {
 }
 
 template <ByteNumbering ByteNumberingV>
 template <std::input_iterator Iterator, ByteNumbering SrcByteNumberingV>
     requires(SrcByteNumberingV == ByteNumberingV || SrcByteNumberingV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None)
-constexpr Bytes<ByteNumberingV>::Bytes(Iterator begin, Iterator end, ByteNumberingType<SrcByteNumberingV>) : data_{ begin, end }
+constexpr BasicBytes<ByteNumberingV>::BasicBytes(Iterator begin, Iterator end, ByteNumberingType<SrcByteNumberingV>) : data_{ begin, end }
 {
 }
 
 template <ByteNumbering ByteNumberingV>
 template <std::input_iterator Iterator, ByteNumbering SrcByteNumberingV>
     requires(SrcByteNumberingV != ByteNumberingV && SrcByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-constexpr Bytes<ByteNumberingV>::Bytes(Iterator begin, Iterator end, ByteNumberingType<SrcByteNumberingV>) : data_{ begin, end }
+constexpr BasicBytes<ByteNumberingV>::BasicBytes(Iterator begin, Iterator end, ByteNumberingType<SrcByteNumberingV>) : data_{ begin, end }
 {
 }
 
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering SrcByteNumberingV>
     requires(SrcByteNumberingV == ByteNumberingV || SrcByteNumberingV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None)
-constexpr Bytes<ByteNumberingV>::Bytes(std::initializer_list<value_type> const il, ByteNumberingType<SrcByteNumberingV>) : data_{ il }
+constexpr BasicBytes<ByteNumberingV>::BasicBytes(std::initializer_list<value_type> const il, ByteNumberingType<SrcByteNumberingV>) : data_{ il }
 {
 }
 
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering SrcByteNumberingV>
     requires(SrcByteNumberingV != ByteNumberingV && SrcByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-constexpr Bytes<ByteNumberingV>::Bytes(std::initializer_list<value_type> const il, ByteNumberingType<SrcByteNumberingV>) : data_{ il }
+constexpr BasicBytes<ByteNumberingV>::BasicBytes(std::initializer_list<value_type> const il, ByteNumberingType<SrcByteNumberingV>) : data_{ il }
 {
     ranges::reverse(data_);
 }
@@ -99,7 +101,7 @@ template <ByteNumbering ByteNumberingV>
 template <ByteNumbering RhsByteNumberingV>
     requires(RhsByteNumberingV != ByteNumberingV && RhsByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
 constexpr auto
-Bytes<ByteNumberingV>::operator=(Bytes<RhsByteNumberingV> && rhs) -> Bytes &
+BasicBytes<ByteNumberingV>::operator=(BasicBytes<RhsByteNumberingV> && rhs) -> BasicBytes &
 {
     data_ = std::move(rhs.data_);
     ranges::reverse(data_);
@@ -110,7 +112,7 @@ template <ByteNumbering ByteNumberingV>
 template <ByteNumbering RhsByteNumberV>
     requires(RhsByteNumberV != ByteNumberingV && (RhsByteNumberV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None))
 constexpr auto
-Bytes<ByteNumberingV>::operator=(Bytes<RhsByteNumberV> && rhs) noexcept -> Bytes &
+BasicBytes<ByteNumberingV>::operator=(BasicBytes<RhsByteNumberV> && rhs) noexcept -> BasicBytes &
 {
     data_ = std::move(rhs.data_);
     return *this;
@@ -118,7 +120,7 @@ Bytes<ByteNumberingV>::operator=(Bytes<RhsByteNumberV> && rhs) noexcept -> Bytes
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::operator=(bytes_view<ByteNumberingV> view) -> Bytes &
+BasicBytes<ByteNumberingV>::operator=(bytes_view<ByteNumberingV> view) -> BasicBytes &
 {
     data_.assign(std::begin(view), std::end(view));
     return *this;
@@ -128,7 +130,7 @@ template <ByteNumbering ByteNumberingV>
 template <ByteNumbering ViewByteNumberingV>
     requires(ViewByteNumberingV != ByteNumberingV && ViewByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
 constexpr auto
-Bytes<ByteNumberingV>::operator=(bytes_view<ViewByteNumberingV> view) -> Bytes &
+BasicBytes<ByteNumberingV>::operator=(bytes_view<ViewByteNumberingV> view) -> BasicBytes &
 {
     data_.assign(std::begin(view), std::end(view));
     ranges::reverse(data_);
@@ -139,7 +141,7 @@ template <ByteNumbering ByteNumberingV>
 template <ByteNumbering ViewByteNumberingV>
     requires(ViewByteNumberingV != ByteNumberingV && (ViewByteNumberingV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None))
 constexpr auto
-Bytes<ByteNumberingV>::operator=(bytes_view<ViewByteNumberingV> view) -> Bytes &
+BasicBytes<ByteNumberingV>::operator=(bytes_view<ViewByteNumberingV> view) -> BasicBytes &
 {
     data_.assign(std::begin(view), std::end(view));
     return *this;
@@ -147,7 +149,7 @@ Bytes<ByteNumberingV>::operator=(bytes_view<ViewByteNumberingV> view) -> Bytes &
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::operator=(std::initializer_list<value_type> const il) -> Bytes &
+BasicBytes<ByteNumberingV>::operator=(std::initializer_list<value_type> const il) -> BasicBytes &
 {
     data_ = il;
     return *this;
@@ -156,15 +158,15 @@ Bytes<ByteNumberingV>::operator=(std::initializer_list<value_type> const il) -> 
 template <ByteNumbering ByteNumberingV>
 template <std::integral T>
 constexpr auto
-Bytes<ByteNumberingV>::from(T i) -> Bytes
+BasicBytes<ByteNumberingV>::from(T i) -> BasicBytes
 {
-    Bytes bs;
+    BasicBytes bs;
     bs.reserve(sizeof(i));
 
     for (std::size_t j = 0; j < sizeof(T) && i != 0; ++j)
     {
         // force little endian
-        bs.push_back(static_cast<byte>(i));
+        bs.push_back(static_cast<byte_t>(i));
         i >>= 8;
     }
 
@@ -179,48 +181,48 @@ Bytes<ByteNumberingV>::from(T i) -> Bytes
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering DataByteNumberingV, std::input_iterator InputIterator>
 constexpr auto
-Bytes<ByteNumberingV>::from(InputIterator begin, InputIterator end) -> Bytes
+BasicBytes<ByteNumberingV>::from(InputIterator begin, InputIterator end) -> BasicBytes
 {
-    return Bytes{ begin, end, ByteNumberingType<DataByteNumberingV>{} };
+    return BasicBytes{ begin, end, ByteNumberingType<DataByteNumberingV>{} };
 }
 
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering ViewByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::from(bytes_view<ViewByteNumberingV> const view) -> Bytes
+BasicBytes<ByteNumberingV>::from(bytes_view<ViewByteNumberingV> const view) -> BasicBytes
 {
-    return Bytes{ view };
+    return BasicBytes{ view };
 }
 
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering DataByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::from(std::initializer_list<byte> il) -> Bytes
+BasicBytes<ByteNumberingV>::from(std::initializer_list<byte_t> il) -> BasicBytes
 {
-    return Bytes{ il, ByteNumberingType<DataByteNumberingV>{} };
+    return BasicBytes{ il, ByteNumberingType<DataByteNumberingV>{} };
 }
 
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering RhsByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::from(Bytes<RhsByteNumberingV> && rhs) -> Bytes
+BasicBytes<ByteNumberingV>::from(BasicBytes<RhsByteNumberingV> && rhs) -> BasicBytes
 {
-    return Bytes{ std::move(rhs) };
+    return BasicBytes{ std::move(rhs) };
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::from(std::string_view str) -> Bytes
+BasicBytes<ByteNumberingV>::from(std::string_view str) -> BasicBytes
     requires(ByteNumberingV == ByteNumbering::None)
 {
-    return Bytes{ str };
+    return BasicBytes{ str };
 }
 
 template <ByteNumbering ByteNumberingV>
 template <std::integral T>
     requires(ByteNumberingV != ByteNumbering::None)
 constexpr auto
-Bytes<ByteNumberingV>::to() const noexcept -> T
+BasicBytes<ByteNumberingV>::to() const noexcept -> T
 {
     assert(data_.size() <= sizeof(T));
 
@@ -249,204 +251,204 @@ template <ByteNumbering ByteNumberingV>
 template <ByteNumbering ToByteNumberingV>
     requires(ByteNumberingV != ToByteNumberingV)
 constexpr auto
-Bytes<ByteNumberingV>::to() const & -> Bytes<ToByteNumberingV>
+BasicBytes<ByteNumberingV>::to() const & -> BasicBytes<ToByteNumberingV>
 {
-    return Bytes<ToByteNumberingV>{ static_cast<bytes_view<ByteNumberingV>>(*this) };
+    return BasicBytes<ToByteNumberingV>{ static_cast<bytes_view<ByteNumberingV>>(*this) };
 }
 
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering ToByteNumberingV>
     requires(ByteNumberingV != ToByteNumberingV)
 constexpr auto
-Bytes<ByteNumberingV>::to() && -> Bytes<ToByteNumberingV>
+BasicBytes<ByteNumberingV>::to() && -> BasicBytes<ToByteNumberingV>
 {
-    return Bytes<ToByteNumberingV>{ std::move(*this) };
+    return BasicBytes<ToByteNumberingV>{ std::move(*this) };
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::assign(size_type const count, byte const & value) -> void
+BasicBytes<ByteNumberingV>::assign(size_type const count, byte_t const & value) -> void
 {
     data_.assign(count, value);
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::at(size_type const pos) -> reference
+BasicBytes<ByteNumberingV>::at(size_type const pos) -> reference
 {
     return data_.at(pos);
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::at(size_type const pos) const -> const_reference
+BasicBytes<ByteNumberingV>::at(size_type const pos) const -> const_reference
 {
     return data_.at(pos);
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::operator[](size_type const pos) -> reference
+BasicBytes<ByteNumberingV>::operator[](size_type const pos) -> reference
 {
     return data_[pos];
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::operator[](size_type const pos) const -> const_reference
+BasicBytes<ByteNumberingV>::operator[](size_type const pos) const -> const_reference
 {
     return data_[pos];
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::front() -> reference
+BasicBytes<ByteNumberingV>::front() -> reference
 {
     return data_.front();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::front() const -> const_reference
+BasicBytes<ByteNumberingV>::front() const -> const_reference
 {
     return data_.front();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::back() -> reference
+BasicBytes<ByteNumberingV>::back() -> reference
 {
     return data_.back();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::back() const -> const_reference
+BasicBytes<ByteNumberingV>::back() const -> const_reference
 {
     return data_.back();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::data() noexcept -> value_type *
+BasicBytes<ByteNumberingV>::data() noexcept -> value_type *
 {
     return data_.data();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::data() const noexcept -> value_type const *
+BasicBytes<ByteNumberingV>::data() const noexcept -> value_type const *
 {
     return data_.data();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::begin() noexcept -> iterator
+BasicBytes<ByteNumberingV>::begin() noexcept -> iterator
 {
     return data_.begin();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::begin() const noexcept -> const_iterator
+BasicBytes<ByteNumberingV>::begin() const noexcept -> const_iterator
 {
     return data_.begin();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::cbegin() const noexcept -> const_iterator
+BasicBytes<ByteNumberingV>::cbegin() const noexcept -> const_iterator
 {
     return data_.cbegin();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::end() noexcept -> iterator
+BasicBytes<ByteNumberingV>::end() noexcept -> iterator
 {
     return data_.end();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::end() const noexcept -> const_iterator
+BasicBytes<ByteNumberingV>::end() const noexcept -> const_iterator
 {
     return data_.end();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::cend() const noexcept -> const_iterator
+BasicBytes<ByteNumberingV>::cend() const noexcept -> const_iterator
 {
     return data_.cend();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::empty() const noexcept -> bool
+BasicBytes<ByteNumberingV>::empty() const noexcept -> bool
 {
     return data_.empty();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::size() const noexcept -> size_type
+BasicBytes<ByteNumberingV>::size() const noexcept -> size_type
 {
     return data_.size();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::resize(size_type new_size) -> void
+BasicBytes<ByteNumberingV>::resize(size_type new_size) -> void
 {
     data_.resize(new_size);
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::reserve(size_type const new_cap) -> void
+BasicBytes<ByteNumberingV>::reserve(size_type const new_cap) -> void
 {
     data_.reserve(new_cap);
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr void
-Bytes<ByteNumberingV>::clear() noexcept
+BasicBytes<ByteNumberingV>::clear() noexcept
 {
     data_.clear();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr void
-Bytes<ByteNumberingV>::push_back(value_type const value)
+BasicBytes<ByteNumberingV>::push_back(value_type const value)
 {
     data_.push_back(value);
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr void
-Bytes<ByteNumberingV>::pop_back()
+BasicBytes<ByteNumberingV>::pop_back()
 {
     data_.pop_back();
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr void
-Bytes<ByteNumberingV>::swap(Bytes & other) noexcept
+BasicBytes<ByteNumberingV>::swap(BasicBytes & other) noexcept
 {
     data_.swap(other.data_);
 }
 
 template <ByteNumbering ByteNumberingV>
-constexpr Bytes<ByteNumberingV>::operator std::vector<byte> const &() const noexcept
+constexpr BasicBytes<ByteNumberingV>::operator std::vector<byte_t> const &() const noexcept
     requires(ByteNumberingV == ByteNumbering::None)
 {
     return data_;
 }
 
 template <ByteNumbering ByteNumberingV>
-constexpr Bytes<ByteNumberingV>::operator std::vector<byte> &() noexcept
+constexpr BasicBytes<ByteNumberingV>::operator std::vector<byte_t> &() noexcept
     requires(ByteNumberingV == ByteNumbering::None)
 {
     return data_;
@@ -454,7 +456,7 @@ constexpr Bytes<ByteNumberingV>::operator std::vector<byte> &() noexcept
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::least_significant_byte() const -> const_reference
+BasicBytes<ByteNumberingV>::least_significant_byte() const -> const_reference
     requires(ByteNumberingV != ByteNumbering::None)
 {
     if constexpr (ByteNumberingV == ByteNumbering::Msb0)
@@ -472,7 +474,7 @@ Bytes<ByteNumberingV>::least_significant_byte() const -> const_reference
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::least_significant_byte() -> reference
+BasicBytes<ByteNumberingV>::least_significant_byte() -> reference
     requires(ByteNumberingV != ByteNumbering::None)
 {
     if constexpr (ByteNumberingV == ByteNumbering::Msb0)
@@ -490,7 +492,7 @@ Bytes<ByteNumberingV>::least_significant_byte() -> reference
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::most_significant_byte() const -> const_reference
+BasicBytes<ByteNumberingV>::most_significant_byte() const -> const_reference
     requires(ByteNumberingV != ByteNumbering::None)
 {
     if constexpr (ByteNumberingV == ByteNumbering::Msb0)
@@ -508,7 +510,7 @@ Bytes<ByteNumberingV>::most_significant_byte() const -> const_reference
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::most_significant_byte() -> reference
+BasicBytes<ByteNumberingV>::most_significant_byte() -> reference
     requires(ByteNumberingV != ByteNumbering::None)
 {
     if constexpr (ByteNumberingV == ByteNumbering::Msb0)
@@ -526,7 +528,7 @@ Bytes<ByteNumberingV>::most_significant_byte() -> reference
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::first(size_t const count) const noexcept -> bytes_view<ByteNumberingV>
+BasicBytes<ByteNumberingV>::first(size_t const count) const noexcept -> bytes_view<ByteNumberingV>
 {
     assert(count <= data_.size());
     return bytes_view<ByteNumberingV>{ std::addressof(data_[0]), count };
@@ -534,7 +536,7 @@ Bytes<ByteNumberingV>::first(size_t const count) const noexcept -> bytes_view<By
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::last(size_t const count) const noexcept -> bytes_view<ByteNumberingV>
+BasicBytes<ByteNumberingV>::last(size_t const count) const noexcept -> bytes_view<ByteNumberingV>
 {
     assert(count <= data_.size());
     return bytes_view<ByteNumberingV>::from(std::addressof(data_[size() - count]), count, ByteNumberingType<ByteNumberingV>{});
@@ -542,7 +544,7 @@ Bytes<ByteNumberingV>::last(size_t const count) const noexcept -> bytes_view<Byt
 
 template <ByteNumbering ByteNumberingV>
 auto
-Bytes<ByteNumberingV>::subview(size_type const pos, size_type const n) const -> expected<bytes_view<ByteNumberingV>, std::error_code>
+BasicBytes<ByteNumberingV>::subview(size_type const pos, size_type const n) const -> expected<bytes_view<ByteNumberingV>, std::error_code>
 {
     if (pos >= data_.size())
     {
@@ -554,14 +556,14 @@ Bytes<ByteNumberingV>::subview(size_type const pos, size_type const n) const -> 
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::view() const noexcept -> bytes_view<ByteNumberingV>
+BasicBytes<ByteNumberingV>::view() const noexcept -> bytes_view<ByteNumberingV>
 {
     return static_cast<bytes_view<ByteNumberingV>>(*this);
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::operator+(byte const other) const -> Bytes
+BasicBytes<ByteNumberingV>::operator+(byte_t const other) const -> BasicBytes
 {
     auto result = *this;
     return result += other;
@@ -569,7 +571,7 @@ Bytes<ByteNumberingV>::operator+(byte const other) const -> Bytes
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::operator+=(byte const other) -> Bytes &
+BasicBytes<ByteNumberingV>::operator+=(byte_t const other) -> BasicBytes &
 {
     data_.reserve(size() + 1);
     data_.push_back(other);
@@ -578,7 +580,7 @@ Bytes<ByteNumberingV>::operator+=(byte const other) -> Bytes &
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::operator+(bytes_view<ByteNumberingV> const other) const -> Bytes
+BasicBytes<ByteNumberingV>::operator+(bytes_view<ByteNumberingV> const other) const -> BasicBytes
 {
     auto data = *this;
     return data += other;
@@ -586,7 +588,7 @@ Bytes<ByteNumberingV>::operator+(bytes_view<ByteNumberingV> const other) const -
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-Bytes<ByteNumberingV>::operator+=(bytes_view<ByteNumberingV> const other) -> Bytes &
+BasicBytes<ByteNumberingV>::operator+=(bytes_view<ByteNumberingV> const other) -> BasicBytes &
 {
     data_.reserve(size() + other.size());
     ranges::copy(other, std::back_inserter(data_));
@@ -594,50 +596,50 @@ Bytes<ByteNumberingV>::operator+=(bytes_view<ByteNumberingV> const other) -> Byt
 }
 
 template <ByteNumbering ByteNumberingV>
-constexpr Bytes<ByteNumberingV>::operator bytes_view<ByteNumberingV>() const noexcept
+constexpr BasicBytes<ByteNumberingV>::operator bytes_view<ByteNumberingV>() const noexcept
 {
     return bytes_view<ByteNumberingV>::from(data(), size(), ByteNumberingType<ByteNumberingV>{});
 }
 
 [[nodiscard]] constexpr auto
-operator<=>(Bytes<ByteNumbering::None> const & lhs, std::vector<byte> const & rhs) -> std::strong_ordering
+operator<=>(BasicBytes<ByteNumbering::None> const & lhs, std::vector<byte_t> const & rhs) -> std::strong_ordering
 {
-    return static_cast<std::vector<byte>>(lhs) <=> rhs;
+    return static_cast<std::vector<byte_t>>(lhs) <=> rhs;
 }
 
 [[nodiscard]] constexpr auto
-operator==(Bytes<ByteNumbering::None> const & lhs, std::vector<byte> const & rhs) -> bool
+operator==(BasicBytes<ByteNumbering::None> const & lhs, std::vector<byte_t> const & rhs) -> bool
 {
-    return static_cast<std::vector<byte>>(lhs) == rhs;
+    return static_cast<std::vector<byte_t>>(lhs) == rhs;
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-operator+(byte const lhs, bytes_view<ByteNumberingV> const & rhs) -> Bytes<ByteNumberingV>
+operator+(byte_t const lhs, bytes_view<ByteNumberingV> const & rhs) -> BasicBytes<ByteNumberingV>
 {
-    return Bytes<ByteNumberingV>{ lhs } + rhs;
+    return BasicBytes<ByteNumberingV>{ lhs } + rhs;
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr void
-swap(Bytes<ByteNumberingV> & lhs, Bytes<ByteNumberingV> & rhs) noexcept
+swap(BasicBytes<ByteNumberingV> & lhs, BasicBytes<ByteNumberingV> & rhs) noexcept
 {
     lhs.swap(rhs);
 }
 
 constexpr auto
-erase(Bytes<ByteNumbering::None> & c, Bytes<ByteNumbering::None>::value_type const value) -> Bytes<ByteNumbering::None>::size_type
+erase(BasicBytes<ByteNumbering::None> & c, BasicBytes<ByteNumbering::None>::value_type const value) -> BasicBytes<ByteNumbering::None>::size_type
 {
-    return std::erase(static_cast<std::vector<byte> &>(c), value);
+    return std::erase(static_cast<std::vector<byte_t> &>(c), value);
 }
 
 template <typename Predictor>
 constexpr auto
-erase_if(Bytes<ByteNumbering::None> & c, Predictor predictor) -> Bytes<ByteNumbering::None>::size_type
+erase_if(BasicBytes<ByteNumbering::None> & c, Predictor predictor) -> BasicBytes<ByteNumbering::None>::size_type
 {
-    return std::erase_if(static_cast<std::vector<byte> &>(c), std::move(predictor));
+    return std::erase_if(static_cast<std::vector<byte_t> &>(c), std::move(predictor));
 }
 
 } // namespace abc
 
-#endif
+#endif // ABC_INCLUDE_ABC_BASIC_BYTES

--- a/include/abc/bytes_decl.h
+++ b/include/abc/bytes_decl.h
@@ -1,8 +1,8 @@
 // Copyright(c) 2023 - present, Payton Wu (payton.wu@outlook.com) & the contributors.
 // Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-#ifndef ABC_INCLUDE_ABC_BYTES_DECL
-#define ABC_INCLUDE_ABC_BYTES_DECL
+#ifndef ABC_INCLUDE_ABC_BASIC_BYTES_DECL
+#define ABC_INCLUDE_ABC_BASIC_BYTES_DECL
 
 #pragma once
 
@@ -16,13 +16,13 @@ namespace abc
 {
 
 template <ByteNumbering ByteNumberingV>
-class Bytes
+class BasicBytes
 {
 private:
     template <ByteNumbering RhsByteNumberingVV>
-    friend class Bytes;
+    friend class BasicBytes;
 
-    using internal_type = std::vector<byte>;
+    using internal_type = std::vector<byte_t>;
 
     internal_type data_{};
 
@@ -44,88 +44,88 @@ public:
 
     // public constructors
 
-    Bytes() = default;
+    BasicBytes() = default;
 
     template <ByteNumbering RhsByteNumberingV>
         requires(RhsByteNumberingV != ByteNumberingV && RhsByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-    constexpr explicit Bytes(Bytes<RhsByteNumberingV> && rhs);
+    constexpr explicit BasicBytes(BasicBytes<RhsByteNumberingV> && rhs);
 
     template <ByteNumbering RhsByteNumberV>
         requires(RhsByteNumberV != ByteNumberingV && (RhsByteNumberV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None))
-    constexpr explicit Bytes(Bytes<RhsByteNumberV> && rhs) noexcept;
+    constexpr explicit BasicBytes(BasicBytes<RhsByteNumberV> && rhs) noexcept;
 
-    constexpr explicit Bytes(bytes_view<ByteNumberingV> view);
+    constexpr explicit BasicBytes(bytes_view<ByteNumberingV> view);
 
     template <ByteNumbering ViewByteNumberingV>
         requires(ViewByteNumberingV != ByteNumberingV && ViewByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-    constexpr explicit Bytes(bytes_view<ViewByteNumberingV> view);
+    constexpr explicit BasicBytes(bytes_view<ViewByteNumberingV> view);
 
     template <ByteNumbering ViewByteNumberingV>
         requires(ViewByteNumberingV != ByteNumberingV && (ViewByteNumberingV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None))
-    constexpr explicit Bytes(bytes_view<ViewByteNumberingV> view);
+    constexpr explicit BasicBytes(bytes_view<ViewByteNumberingV> view);
 
-    constexpr explicit Bytes(std::string_view str)
+    constexpr explicit BasicBytes(std::string_view str)
         requires(ByteNumberingV == ByteNumbering::None);
 
-    constexpr Bytes(std::initializer_list<value_type> il);
+    constexpr BasicBytes(std::initializer_list<value_type> il);
 
     // constexpr auto
-    // operator=(std::vector<byte> raw) noexcept -> Bytes & requires(ByteNumbering == ByteNumbering::none);
+    // operator=(std::vector<byte_t> raw) noexcept -> BasicBytes & requires(ByteNumbering == ByteNumbering::none);
 
     template <ByteNumbering RhsByteNumberingV>
         requires(RhsByteNumberingV != ByteNumberingV && RhsByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-    constexpr auto operator=(Bytes<RhsByteNumberingV> && rhs) -> Bytes &;
+    constexpr auto operator=(BasicBytes<RhsByteNumberingV> && rhs) -> BasicBytes &;
 
     template <ByteNumbering RhsByteNumberV>
         requires(RhsByteNumberV != ByteNumberingV && (RhsByteNumberV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None))
-    constexpr auto operator=(Bytes<RhsByteNumberV> && rhs) noexcept -> Bytes &;
+    constexpr auto operator=(BasicBytes<RhsByteNumberV> && rhs) noexcept -> BasicBytes &;
 
-    constexpr auto operator=(bytes_view<ByteNumberingV> view) -> Bytes &;
+    constexpr auto operator=(bytes_view<ByteNumberingV> view) -> BasicBytes &;
 
     template <ByteNumbering ViewByteNumberingV>
         requires(ViewByteNumberingV != ByteNumberingV && ViewByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-    constexpr auto operator=(bytes_view<ViewByteNumberingV> view) -> Bytes &;
+    constexpr auto operator=(bytes_view<ViewByteNumberingV> view) -> BasicBytes &;
 
     template <ByteNumbering ViewByteNumberingV>
         requires(ViewByteNumberingV != ByteNumberingV && (ViewByteNumberingV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None))
-    constexpr auto operator=(bytes_view<ViewByteNumberingV> view) -> Bytes &;
+    constexpr auto operator=(bytes_view<ViewByteNumberingV> view) -> BasicBytes &;
 
-    constexpr auto operator=(std::initializer_list<value_type> il) -> Bytes &;
+    constexpr auto operator=(std::initializer_list<value_type> il) -> BasicBytes &;
 
 private:
     template <std::input_iterator Iterator, ByteNumbering SrcByteNumberingV>
         requires(SrcByteNumberingV == ByteNumberingV || SrcByteNumberingV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None)
-    constexpr Bytes(Iterator begin, Iterator end, ByteNumberingType<SrcByteNumberingV>);
+    constexpr BasicBytes(Iterator begin, Iterator end, ByteNumberingType<SrcByteNumberingV>);
 
     template <std::input_iterator Iterator, ByteNumbering SrcByteNumberingV>
         requires(SrcByteNumberingV != ByteNumberingV && SrcByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-    constexpr Bytes(Iterator begin, Iterator end, ByteNumberingType<SrcByteNumberingV>);
+    constexpr BasicBytes(Iterator begin, Iterator end, ByteNumberingType<SrcByteNumberingV>);
 
     template <ByteNumbering SrcByteNumberingV>
         requires(SrcByteNumberingV == ByteNumberingV || SrcByteNumberingV == ByteNumbering::None || ByteNumberingV == ByteNumbering::None)
-    constexpr Bytes(std::initializer_list<value_type> il, ByteNumberingType<SrcByteNumberingV>);
+    constexpr BasicBytes(std::initializer_list<value_type> il, ByteNumberingType<SrcByteNumberingV>);
 
     template <ByteNumbering SrcByteNumberingV>
         requires(SrcByteNumberingV != ByteNumberingV && SrcByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-    constexpr Bytes(std::initializer_list<value_type> il, ByteNumberingType<SrcByteNumberingV>);
+    constexpr BasicBytes(std::initializer_list<value_type> il, ByteNumberingType<SrcByteNumberingV>);
 
 public:
     template <std::integral T>
-    constexpr static auto from(T i) -> Bytes;
+    constexpr static auto from(T i) -> BasicBytes;
 
     template <ByteNumbering DataByteNumberingV, std::input_iterator InputIterator>
-    constexpr static auto from(InputIterator begin, InputIterator end) -> Bytes;
+    constexpr static auto from(InputIterator begin, InputIterator end) -> BasicBytes;
 
     template <ByteNumbering ViewByteNumberingV>
-    constexpr static auto from(bytes_view<ViewByteNumberingV> view) -> Bytes;
+    constexpr static auto from(bytes_view<ViewByteNumberingV> view) -> BasicBytes;
 
     template <ByteNumbering DataByteNumberingV>
-    constexpr static auto from(std::initializer_list<byte> il) -> Bytes;
+    constexpr static auto from(std::initializer_list<byte_t> il) -> BasicBytes;
 
     template <ByteNumbering RhsByteNumberingV>
-    constexpr static auto from(Bytes<RhsByteNumberingV> && rhs) -> Bytes;
+    constexpr static auto from(BasicBytes<RhsByteNumberingV> && rhs) -> BasicBytes;
 
-    constexpr static auto from(std::string_view str) -> Bytes
+    constexpr static auto from(std::string_view str) -> BasicBytes
         requires(ByteNumberingV == ByteNumbering::None);
 
     template <std::integral T>
@@ -134,13 +134,13 @@ public:
 
     template <ByteNumbering ToByteNumberingV>
         requires(ByteNumberingV != ToByteNumberingV)
-    constexpr auto to() const & -> Bytes<ToByteNumberingV>;
+    constexpr auto to() const & -> BasicBytes<ToByteNumberingV>;
 
     template <ByteNumbering ToByteNumberingV>
         requires(ByteNumberingV != ToByteNumberingV)
-    constexpr auto to() && -> Bytes<ToByteNumberingV>;
+    constexpr auto to() && -> BasicBytes<ToByteNumberingV>;
 
-    constexpr auto assign(size_type count, byte const & value) -> void;
+    constexpr auto assign(size_type count, byte_t const & value) -> void;
 
     [[nodiscard]] constexpr auto at(size_type pos) -> reference;
 
@@ -188,12 +188,12 @@ public:
 
     constexpr void pop_back();
 
-    constexpr void swap(Bytes & other) noexcept;
+    constexpr void swap(BasicBytes & other) noexcept;
 
-    constexpr explicit operator std::vector<byte> const &() const noexcept
+    constexpr explicit operator std::vector<byte_t> const &() const noexcept
         requires(ByteNumberingV == ByteNumbering::None);
 
-    constexpr explicit operator std::vector<byte> &() noexcept
+    constexpr explicit operator std::vector<byte_t> &() noexcept
         requires(ByteNumberingV == ByteNumbering::None);
 
     [[nodiscard]] constexpr auto least_significant_byte() const -> const_reference
@@ -216,37 +216,37 @@ public:
 
     constexpr auto view() const noexcept -> bytes_view<ByteNumberingV>;
 
-    constexpr auto operator+(byte other) const -> Bytes;
+    constexpr auto operator+(byte_t other) const -> BasicBytes;
 
-    constexpr auto operator+=(byte other) -> Bytes &;
+    constexpr auto operator+=(byte_t other) -> BasicBytes &;
 
-    constexpr auto operator+(bytes_view<ByteNumberingV> other) const -> Bytes;
+    constexpr auto operator+(bytes_view<ByteNumberingV> other) const -> BasicBytes;
 
-    constexpr auto operator+=(bytes_view<ByteNumberingV> other) -> Bytes &;
+    constexpr auto operator+=(bytes_view<ByteNumberingV> other) -> BasicBytes &;
 
     constexpr operator bytes_view<ByteNumberingV>() const noexcept;
 
 private:
-    friend constexpr auto operator==(Bytes const & lhs, Bytes const & rhs) noexcept -> bool = default;
+    friend constexpr auto operator==(BasicBytes const & lhs, BasicBytes const & rhs) noexcept -> bool = default;
 
-    friend constexpr auto operator<=>(Bytes const & lhs, Bytes const & rhs) noexcept -> std::strong_ordering = default;
+    friend constexpr auto operator<=>(BasicBytes const & lhs, BasicBytes const & rhs) noexcept -> std::strong_ordering = default;
 };
 
-[[nodiscard]] constexpr auto operator<=>(Bytes<ByteNumbering::None> const & lhs, std::vector<byte> const & rhs) -> std::strong_ordering;
+[[nodiscard]] constexpr auto operator<=>(BasicBytes<ByteNumbering::None> const & lhs, std::vector<byte_t> const & rhs) -> std::strong_ordering;
 
-[[nodiscard]] constexpr auto operator==(Bytes<ByteNumbering::None> const & lhs, std::vector<byte> const & rhs) -> bool;
-
-template <ByteNumbering ByteNumbering>
-constexpr auto operator+(byte lhs, bytes_view<ByteNumbering> const & rhs) -> Bytes<ByteNumbering>;
+[[nodiscard]] constexpr auto operator==(BasicBytes<ByteNumbering::None> const & lhs, std::vector<byte_t> const & rhs) -> bool;
 
 template <ByteNumbering ByteNumbering>
-constexpr void swap(Bytes<ByteNumbering> & lhs, Bytes<ByteNumbering> & rhs) noexcept;
+constexpr auto operator+(byte_t lhs, bytes_view<ByteNumbering> const & rhs) -> BasicBytes<ByteNumbering>;
 
-constexpr auto erase(Bytes<ByteNumbering::None> & c, Bytes<ByteNumbering::None>::value_type value) -> Bytes<ByteNumbering::None>::size_type;
+template <ByteNumbering ByteNumbering>
+constexpr void swap(BasicBytes<ByteNumbering> & lhs, BasicBytes<ByteNumbering> & rhs) noexcept;
+
+constexpr auto erase(BasicBytes<ByteNumbering::None> & c, BasicBytes<ByteNumbering::None>::value_type value) -> BasicBytes<ByteNumbering::None>::size_type;
 
 template <typename Predictor>
-constexpr auto erase_if(Bytes<ByteNumbering::None> & c, Predictor predictor) -> Bytes<ByteNumbering::None>::size_type;
+constexpr auto erase_if(BasicBytes<ByteNumbering::None> & c, Predictor predictor) -> BasicBytes<ByteNumbering::None>::size_type;
 
 } // namespace abc
 
-#endif // ABC_INCLUDE_ABC_BYTES_DECL
+#endif // ABC_INCLUDE_ABC_BASIC_BYTES_DECL

--- a/include/abc/bytes_fwd_decl.h
+++ b/include/abc/bytes_fwd_decl.h
@@ -1,8 +1,8 @@
 // Copyright(c) 2023 - present, Payton Wu (payton.wu@outlook.com) & the contributors.
 // Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-#ifndef ABC_INCLUDE_ABC_BYTES_FWD_DECL
-#define ABC_INCLUDE_ABC_BYTES_FWD_DECL
+#ifndef ABC_INCLUDE_ABC_BASIC_BYTES_FWD_DECL
+#define ABC_INCLUDE_ABC_BASIC_BYTES_FWD_DECL
 
 #pragma once
 
@@ -12,13 +12,14 @@ namespace abc
 {
 
 template <ByteNumbering ByteNumberingV>
-class [[nodiscard]] Bytes;
+class [[nodiscard]] BasicBytes;
 
-using bytes_t = Bytes<ByteNumbering::None>;
-using bytes_msb0_t = Bytes<ByteNumbering::Msb0>;
-using bytes_lsb0_t = Bytes<ByteNumbering::Lsb0>;
-using bytes_be_t = bytes_msb0_t;
-using bytes_le_t = bytes_lsb0_t;
-}
+using Bytes = BasicBytes<ByteNumbering::None>;
+using Msb0Bytes = BasicBytes<ByteNumbering::Msb0>;
+using Lsb0Bytes = BasicBytes<ByteNumbering::Lsb0>;
+using BigEndianBytes = Msb0Bytes;
+using LittleEndianBytes = Lsb0Bytes;
 
-#endif //ABC_INCLUDE_ABC_BYTES_FWD_DECL
+} // namespace abc
+
+#endif // ABC_INCLUDE_ABC_BASIC_BYTES_FWD_DECL

--- a/include/abc/bytes_view.h
+++ b/include/abc/bytes_view.h
@@ -22,13 +22,14 @@ namespace abc
 template <ByteNumbering ByteNumberingV>
 template <ByteNumbering BufferByteNumberingV>
     requires(BufferByteNumberingV == ByteNumberingV)
-constexpr bytes_view<ByteNumberingV>::bytes_view(byte const * first, size_type count, ByteNumberingType<BufferByteNumberingV>) noexcept : view_{ first, count }
+constexpr bytes_view<ByteNumberingV>::bytes_view(byte_t const * first, size_type count, ByteNumberingType<BufferByteNumberingV>) noexcept : view_{ first, count }
 {
 }
 
 template <ByteNumbering ByteNumberingV>
 template <std::contiguous_iterator It, std::sized_sentinel_for<It> End, ByteNumbering BufferByteNumberingV>
-    requires(std::same_as<std::iter_value_t<It>, abc::byte> && (!std::convertible_to<End, typename bytes_view<ByteNumberingV>::size_type>) && BufferByteNumberingV == ByteNumberingV)
+    requires(std::same_as<std::iter_value_t<It>, abc::byte_t> && (!std::convertible_to<End, typename bytes_view<ByteNumberingV>::size_type>) &&
+             BufferByteNumberingV == ByteNumberingV)
 constexpr bytes_view<ByteNumberingV>::bytes_view(It first, End last, ByteNumberingType<BufferByteNumberingV>) noexcept(noexcept(last - first)) : view_{ first, last }
 {
 }
@@ -37,14 +38,15 @@ template <ByteNumbering ByteNumberingV>
 template <ByteNumbering BufferByteNumberingV>
     requires(BufferByteNumberingV == ByteNumberingV)
 constexpr auto
-bytes_view<ByteNumberingV>::from(abc::byte const * data, size_type size, ByteNumberingType<BufferByteNumberingV>) noexcept -> bytes_view
+bytes_view<ByteNumberingV>::from(abc::byte_t const * data, size_type size, ByteNumberingType<BufferByteNumberingV>) noexcept -> bytes_view
 {
     return bytes_view{ data, size, ByteNumberingType<BufferByteNumberingV>{} };
 }
 
 template <ByteNumbering ByteNumberingV>
 template <std::contiguous_iterator It, std::sized_sentinel_for<It> End, ByteNumbering BufferByteNumberingV>
-    requires(std::same_as<std::iter_value_t<It>, abc::byte> && (!std::convertible_to<End, typename bytes_view<ByteNumberingV>::size_type>) && BufferByteNumberingV == ByteNumberingV)
+    requires(std::same_as<std::iter_value_t<It>, abc::byte_t> && (!std::convertible_to<End, typename bytes_view<ByteNumberingV>::size_type>) &&
+             BufferByteNumberingV == ByteNumberingV)
 constexpr auto
 bytes_view<ByteNumberingV>::from(It first, End last, ByteNumberingType<BufferByteNumberingV>) noexcept(noexcept(last - first)) -> bytes_view
 {
@@ -53,7 +55,7 @@ bytes_view<ByteNumberingV>::from(It first, End last, ByteNumberingType<BufferByt
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-bytes_view<ByteNumberingV>::from(std::span<abc::byte const> bytes) noexcept -> bytes_view
+bytes_view<ByteNumberingV>::from(std::span<abc::byte_t const> bytes) noexcept -> bytes_view
     requires(ByteNumberingV == ByteNumbering::None)
 {
     return bytes_view{ std::begin(bytes), std::end(bytes), ByteNumberingType<ByteNumberingV>{} };
@@ -63,14 +65,14 @@ template <ByteNumbering ByteNumberingV>
 template <ByteNumbering BufferByteNumberingV>
     requires(BufferByteNumberingV == ByteNumberingV)
 constexpr auto
-bytes_view<ByteNumberingV>::from(std::span<abc::byte const> bytes_span, ByteNumberingType<BufferByteNumberingV> bnt) noexcept -> bytes_view
+bytes_view<ByteNumberingV>::from(std::span<abc::byte_t const> bytes_span, ByteNumberingType<BufferByteNumberingV> bnt) noexcept -> bytes_view
 {
     return bytes_view{ std::begin(bytes_span), std::end(bytes_span), bnt };
 }
 
 template <ByteNumbering ByteNumberingV>
 constexpr auto
-bytes_view<ByteNumberingV>::from(std::basic_string_view<abc::byte> sv) noexcept -> bytes_view
+bytes_view<ByteNumberingV>::from(std::basic_string_view<abc::byte_t> sv) noexcept -> bytes_view
     requires(ByteNumberingV == ByteNumbering::None)
 {
     return bytes_view{ std::begin(sv), std::end(sv), ByteNumberingType<ByteNumberingV>{} };
@@ -80,7 +82,7 @@ template <ByteNumbering ByteNumberingV>
 template <ByteNumbering BufferByteNumberingV>
     requires(BufferByteNumberingV == ByteNumberingV)
 constexpr auto
-bytes_view<ByteNumberingV>::from(std::basic_string_view<abc::byte> sv, ByteNumberingType<BufferByteNumberingV> bnt) noexcept -> bytes_view
+bytes_view<ByteNumberingV>::from(std::basic_string_view<abc::byte_t> sv, ByteNumberingType<BufferByteNumberingV> bnt) noexcept -> bytes_view
 {
     return bytes_view{ std::begin(sv), std::end(sv), bnt };
 }

--- a/include/abc/bytes_view_decl.h
+++ b/include/abc/bytes_view_decl.h
@@ -22,7 +22,7 @@ public:
     static constexpr std::size_t npos = std::numeric_limits<std::size_t>::max();
 
 private:
-    using container_type = std::basic_string_view<byte>;
+    using container_type = std::basic_string_view<byte_t>;
     container_type view_{};
 
     template <ByteNumbering>
@@ -44,10 +44,10 @@ public:
 private:
     template <ByteNumbering BufferByteNumberingV>
         requires(BufferByteNumberingV == ByteNumberingV)
-    constexpr bytes_view(byte const * first, size_type count, ByteNumberingType<BufferByteNumberingV>) noexcept;
+    constexpr bytes_view(byte_t const * first, size_type count, ByteNumberingType<BufferByteNumberingV>) noexcept;
 
     template <std::contiguous_iterator It, std::sized_sentinel_for<It> End, ByteNumbering BufferByteNumberingV>
-        requires(std::same_as<std::iter_value_t<It>, abc::byte> && (!std::convertible_to<End, size_type>) && BufferByteNumberingV == ByteNumberingV)
+        requires(std::same_as<std::iter_value_t<It>, abc::byte_t> && (!std::convertible_to<End, size_type>) && BufferByteNumberingV == ByteNumberingV)
     constexpr bytes_view(It first, End last, ByteNumberingType<BufferByteNumberingV>) noexcept(noexcept(last - first));
 
 public:
@@ -63,25 +63,25 @@ public:
 
     template <ByteNumbering BufferByteNumberingV>
         requires(BufferByteNumberingV == ByteNumberingV)
-    constexpr static auto from(abc::byte const * data, size_type size, ByteNumberingType<BufferByteNumberingV>) noexcept -> bytes_view;
+    constexpr static auto from(abc::byte_t const * data, size_type size, ByteNumberingType<BufferByteNumberingV>) noexcept -> bytes_view;
 
     template <std::contiguous_iterator It, std::sized_sentinel_for<It> End, ByteNumbering BufferByteNumberingV>
-        requires(std::same_as<std::iter_value_t<It>, abc::byte> && (!std::convertible_to<End, size_type>) && BufferByteNumberingV == ByteNumberingV)
+        requires(std::same_as<std::iter_value_t<It>, abc::byte_t> && (!std::convertible_to<End, size_type>) && BufferByteNumberingV == ByteNumberingV)
     constexpr static auto from(It first, End last, ByteNumberingType<BufferByteNumberingV>) noexcept(noexcept(last - first)) -> bytes_view;
 
-    constexpr static auto from(std::span<abc::byte const> bytes_span) noexcept -> bytes_view
+    constexpr static auto from(std::span<abc::byte_t const> bytes_span) noexcept -> bytes_view
         requires(ByteNumberingV == ByteNumbering::None);
 
     template <ByteNumbering BufferByteNumberingV>
         requires(BufferByteNumberingV == ByteNumberingV)
-    constexpr static auto from(std::span<abc::byte const> bytes_span, ByteNumberingType<BufferByteNumberingV>) noexcept -> bytes_view;
+    constexpr static auto from(std::span<abc::byte_t const> bytes_span, ByteNumberingType<BufferByteNumberingV>) noexcept -> bytes_view;
 
-    constexpr static auto from(std::basic_string_view<abc::byte> sv) noexcept -> bytes_view
+    constexpr static auto from(std::basic_string_view<abc::byte_t> sv) noexcept -> bytes_view
         requires(ByteNumberingV == ByteNumbering::None);
 
     template <ByteNumbering BufferByteNumberingV>
         requires(BufferByteNumberingV == ByteNumberingV)
-    constexpr static auto from(std::basic_string_view<abc::byte> sv, ByteNumberingType<BufferByteNumberingV>) noexcept -> bytes_view;
+    constexpr static auto from(std::basic_string_view<abc::byte_t> sv, ByteNumberingType<BufferByteNumberingV>) noexcept -> bytes_view;
 
     template <std::integral T>
         requires(ByteNumberingV != ByteNumbering::None)

--- a/include/abc/converter.h
+++ b/include/abc/converter.h
@@ -61,27 +61,27 @@ struct converter<fixed_bytes<N, ByteNumberingV>, hex_string>
             return abc::make_unexpected(make_error_code(std::errc::invalid_argument));
         }
 
-        std::array<byte, N> bytes{};
+        std::array<byte_t, N> bytes{};
         ranges::copy(hex_str.bytes<ByteNumberingV>(), std::begin(bytes));
         return fixed_bytes<N, ByteNumberingV>::template from<ByteNumberingV>(bytes);
     }
 };
 
 template <ByteNumbering ByteNumberingV, std::integral T>
-struct converter<Bytes<ByteNumberingV>, T>
+struct converter<BasicBytes<ByteNumberingV>, T>
 {
     inline static auto
-    from(T const & num) -> abc::expected<Bytes<ByteNumberingV>, std::error_code>
+    from(T const & num) -> abc::expected<BasicBytes<ByteNumberingV>, std::error_code>
     {
-        return Bytes<ByteNumberingV>::from(num);
+        return BasicBytes<ByteNumberingV>::from(num);
     }
 };
 
 template <std::integral T, ByteNumbering ByteNumberingV>
-struct converter<T, Bytes<ByteNumberingV>>
+struct converter<T, BasicBytes<ByteNumberingV>>
 {
     inline static auto
-    from(Bytes<ByteNumberingV> const & number_bytes) -> abc::expected<T, std::error_code>
+    from(BasicBytes<ByteNumberingV> const & number_bytes) -> abc::expected<T, std::error_code>
     {
         return number_bytes.template to<T>();
     }

--- a/include/abc/fixed_bytes.h
+++ b/include/abc/fixed_bytes.h
@@ -31,14 +31,14 @@ namespace abc
 template <std::size_t N, ByteNumbering ByteNumberingV>
 template <ByteNumbering SrcByteNumberingV>
     requires(SrcByteNumberingV == ByteNumberingV)
-constexpr fixed_bytes<N, ByteNumberingV>::fixed_bytes(std::array<byte, N> const & src, ByteNumberingType<SrcByteNumberingV>) : data_{ src }
+constexpr fixed_bytes<N, ByteNumberingV>::fixed_bytes(std::array<byte_t, N> const & src, ByteNumberingType<SrcByteNumberingV>) : data_{ src }
 {
 }
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
 template <ByteNumbering SrcByteNumberingV>
     requires(SrcByteNumberingV != ByteNumberingV && SrcByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-constexpr fixed_bytes<N, ByteNumberingV>::fixed_bytes(std::array<byte, N> const & src, ByteNumberingType<SrcByteNumberingV>)
+constexpr fixed_bytes<N, ByteNumberingV>::fixed_bytes(std::array<byte_t, N> const & src, ByteNumberingType<SrcByteNumberingV>)
 {
     ranges::copy(src | ranges::views::reverse, std::begin(data_));
 }
@@ -48,7 +48,7 @@ template <ByteNumbering SrcByteNumberingV>
     requires(SrcByteNumberingV == ByteNumberingV)
 constexpr fixed_bytes<N, ByteNumberingV>::fixed_bytes(std::array<std::byte, N> const & src, ByteNumberingType<SrcByteNumberingV>)
 {
-    ranges::copy(src | ranges::views::transform([](auto const byte) { return std::to_integer<byte>(byte); }), data_.begin());
+    ranges::copy(src | ranges::views::transform([](auto const byte) { return std::to_integer<byte_t>(byte); }), data_.begin());
 }
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
@@ -56,7 +56,7 @@ template <ByteNumbering SrcByteNumberingV>
     requires(SrcByteNumberingV != ByteNumberingV && SrcByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
 constexpr fixed_bytes<N, ByteNumberingV>::fixed_bytes(std::array<std::byte, N> const & src, ByteNumberingType<SrcByteNumberingV>)
 {
-    ranges::copy(src | ranges::views::reverse | ranges::views::transform([](auto const b) { return std::to_integer<byte>(b); }), data_.begin());
+    ranges::copy(src | ranges::views::reverse | ranges::views::transform([](auto const b) { return std::to_integer<byte_t>(b); }), data_.begin());
 }
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
@@ -151,7 +151,7 @@ constexpr fixed_bytes<N, ByteNumberingV>::fixed_bytes(fixed_bytes<N, ByteNumberi
 template <std::size_t N, ByteNumbering ByteNumberingV>
 template <ByteNumbering DataByteNumberingV>
 auto
-fixed_bytes<N, ByteNumberingV>::from(std::array<byte, N> const & data) -> expected<fixed_bytes, std::error_code>
+fixed_bytes<N, ByteNumberingV>::from(std::array<byte_t, N> const & data) -> expected<fixed_bytes, std::error_code>
 {
     if constexpr (DataByteNumberingV == ByteNumberingV || (DataByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None))
     {
@@ -187,14 +187,14 @@ fixed_bytes<N, ByteNumberingV>::from(bytes_view<DataByteNumberingV> const data) 
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
 constexpr auto
-fixed_bytes<N, ByteNumberingV>::operator[](size_t const index) const noexcept -> byte
+fixed_bytes<N, ByteNumberingV>::operator[](size_t const index) const noexcept -> byte_t
 {
     return data_[index];
 }
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
 constexpr auto
-fixed_bytes<N, ByteNumberingV>::operator[](size_t const index) noexcept -> byte &
+fixed_bytes<N, ByteNumberingV>::operator[](size_t const index) noexcept -> byte_t &
 {
     return data_[index];
 }
@@ -347,7 +347,7 @@ fixed_bytes<N, ByteNumberingV>::size() const noexcept -> size_type
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
 constexpr auto
-fixed_bytes<N, ByteNumberingV>::fill(byte const value) noexcept -> void
+fixed_bytes<N, ByteNumberingV>::fill(byte_t const value) noexcept -> void
 {
     data_.fill(value);
 }
@@ -486,7 +486,7 @@ fixed_bytes<N, ByteNumberingV>::clear() -> void
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
 auto
-fixed_bytes<N, ByteNumberingV>::subbytes(size_type pos, size_type n) const -> expected<Bytes<ByteNumberingV>, std::error_code>
+fixed_bytes<N, ByteNumberingV>::subbytes(size_type pos, size_type n) const -> expected<BasicBytes<ByteNumberingV>, std::error_code>
 {
     if (pos >= size())
     {
@@ -498,7 +498,7 @@ fixed_bytes<N, ByteNumberingV>::subbytes(size_type pos, size_type n) const -> ex
     auto start = std::next(std::begin(data_), pos);
     auto end = std::next(start, offset);
 
-    return abc::Bytes<ByteNumberingV>::template from<ByteNumberingV>(start, end);
+    return abc::BasicBytes<ByteNumberingV>::template from<ByteNumberingV>(start, end);
 }
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
@@ -527,7 +527,7 @@ fixed_bytes<N, ByteNumberingV>::subview(size_type, size_type) const && -> expect
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
 auto
-fixed_bytes<N, ByteNumberingV>::subspan(size_type pos, size_type n) & -> expected<std::span<byte>, std::error_code>
+fixed_bytes<N, ByteNumberingV>::subspan(size_type pos, size_type n) & -> expected<std::span<byte_t>, std::error_code>
 {
     if (pos >= size())
     {
@@ -542,14 +542,14 @@ fixed_bytes<N, ByteNumberingV>::subspan(size_type pos, size_type n) & -> expecte
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
 inline auto
-fixed_bytes<N, ByteNumberingV>::subspan(size_type, size_type) && -> expected<std::span<byte>, std::error_code>
+fixed_bytes<N, ByteNumberingV>::subspan(size_type, size_type) && -> expected<std::span<byte_t>, std::error_code>
 {
     return make_unexpected(make_error_code(errc::span_built_from_rvalue));
 }
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
 auto
-fixed_bytes<N, ByteNumberingV>::subspan(size_type pos, size_type n) const & -> expected<std::span<byte const>, std::error_code>
+fixed_bytes<N, ByteNumberingV>::subspan(size_type pos, size_type n) const & -> expected<std::span<byte_t const>, std::error_code>
 {
     if (pos >= size())
     {
@@ -564,7 +564,7 @@ fixed_bytes<N, ByteNumberingV>::subspan(size_type pos, size_type n) const & -> e
 
 template <std::size_t N, ByteNumbering ByteNumberingV>
 auto
-fixed_bytes<N, ByteNumberingV>::subspan(size_type, size_type) const && -> expected<std::span<byte const>, std::error_code>
+fixed_bytes<N, ByteNumberingV>::subspan(size_type, size_type) const && -> expected<std::span<byte_t const>, std::error_code>
 {
     return make_unexpected(make_error_code(errc::span_built_from_rvalue));
 }

--- a/include/abc/fixed_bytes_decl.h
+++ b/include/abc/fixed_bytes_decl.h
@@ -17,7 +17,7 @@ class fixed_bytes
     static_assert(N > 0);
 
 private:
-    using internal_type = std::array<byte, N>;
+    using internal_type = std::array<byte_t, N>;
     internal_type data_;
 
 public:
@@ -36,11 +36,11 @@ public:
 private:
     template <ByteNumbering SrcByteNumberingV>
         requires(SrcByteNumberingV == ByteNumberingV)
-    constexpr explicit fixed_bytes(std::array<byte, N> const & src, ByteNumberingType<SrcByteNumberingV>);
+    constexpr explicit fixed_bytes(std::array<byte_t, N> const & src, ByteNumberingType<SrcByteNumberingV>);
 
     template <ByteNumbering SrcByteNumberingV>
         requires(SrcByteNumberingV != ByteNumberingV && SrcByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
-    constexpr explicit fixed_bytes(std::array<byte, N> const & src, ByteNumberingType<SrcByteNumberingV>);
+    constexpr explicit fixed_bytes(std::array<byte_t, N> const & src, ByteNumberingType<SrcByteNumberingV>);
 
     template <ByteNumbering SrcByteNumberingV>
         requires(SrcByteNumberingV == ByteNumberingV)
@@ -73,10 +73,11 @@ public:
     constexpr explicit fixed_bytes(fixed_bytes<N, ByteNumberingRhsV> const & rhs);
 
     template <ByteNumbering DataByteNumberingV>
-    static auto from(std::array<byte, N> const & data) -> expected<fixed_bytes, std::error_code>;
+    static auto from(std::array<byte_t, N> const & data) -> expected<fixed_bytes, std::error_code>;
 
     template <ByteNumbering DataByteNumberingV>
-        requires(DataByteNumberingV == ByteNumberingV) || (DataByteNumberingV != ByteNumberingV && DataByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
+        requires(DataByteNumberingV == ByteNumberingV) ||
+                (DataByteNumberingV != ByteNumberingV && DataByteNumberingV != ByteNumbering::None && ByteNumberingV != ByteNumbering::None)
     static auto from(bytes_view<DataByteNumberingV> data) -> expected<fixed_bytes, std::error_code>;
 
     template <ByteNumbering DataByteNumberingV>
@@ -87,9 +88,9 @@ public:
 
     friend auto operator<=>(fixed_bytes const &, fixed_bytes const &) noexcept -> std::strong_ordering = default;
 
-    constexpr auto operator[](size_t index) const noexcept -> byte;
+    constexpr auto operator[](size_t index) const noexcept -> byte_t;
 
-    constexpr auto operator[](size_t index) noexcept -> byte &;
+    constexpr auto operator[](size_t index) noexcept -> byte_t &;
 
     constexpr operator bytes_view<ByteNumberingV>() const noexcept;
 
@@ -133,7 +134,7 @@ public:
 
     [[nodiscard]] constexpr auto size() const noexcept -> size_type;
 
-    constexpr auto fill(byte value) noexcept -> void;
+    constexpr auto fill(byte_t value) noexcept -> void;
 
     [[nodiscard]] constexpr static auto byte_numbering() noexcept -> abc::ByteNumbering;
 
@@ -160,23 +161,23 @@ public:
 
     constexpr auto clear() -> void;
 
-    auto subbytes(size_type pos, size_type n = static_cast<size_t>(-1)) const -> expected<Bytes<ByteNumberingV>, std::error_code>;
+    auto subbytes(size_type pos, size_type n = static_cast<size_t>(-1)) const -> expected<BasicBytes<ByteNumberingV>, std::error_code>;
 
     auto subview(size_type pos, size_type n = static_cast<size_type>(-1)) const & -> expected<bytes_view<ByteNumberingV>, std::error_code>;
 
     auto subview(size_type, size_type = static_cast<size_type>(-1)) const && -> expected<bytes_view<ByteNumberingV>, std::error_code>;
 
-    inline auto subspan(size_type pos, size_type n = static_cast<size_t>(-1)) & -> expected<std::span<byte>, std::error_code>;
+    inline auto subspan(size_type pos, size_type n = static_cast<size_t>(-1)) & -> expected<std::span<byte_t>, std::error_code>;
 
     /// @brief make span from rvalue fixed_bytes. not allowed.
     /// @return an std::error_code with errc::span_built_from_rvalue.
-    auto subspan(size_type, size_type = static_cast<size_t>(-1)) && -> expected<std::span<byte>, std::error_code>;
+    auto subspan(size_type, size_type = static_cast<size_t>(-1)) && -> expected<std::span<byte_t>, std::error_code>;
 
-    inline auto subspan(size_type pos, size_type n = static_cast<size_t>(-1)) const & -> expected<std::span<byte const>, std::error_code>;
+    inline auto subspan(size_type pos, size_type n = static_cast<size_t>(-1)) const & -> expected<std::span<byte_t const>, std::error_code>;
 
     /// @brief make span from rvalue fixed_bytes. not allowed.
     /// @return an std::error_code with errc::span_built_from_rvalue.
-    inline auto subspan(size_type, size_type = static_cast<size_t>(-1)) const && -> expected<std::span<byte const>, std::error_code>;
+    inline auto subspan(size_type, size_type = static_cast<size_t>(-1)) const && -> expected<std::span<byte_t const>, std::error_code>;
 
 private:
     template <std::unsigned_integral T>

--- a/include/abc/hex_string.h
+++ b/include/abc/hex_string.h
@@ -67,7 +67,7 @@ hex_string::reference::operator=(char const value) -> reference &
     return *this;
 }
 
-constexpr hex_string::hex_string(bytes_le_t && input) noexcept : binary_data_{ std::move(input) }
+constexpr hex_string::hex_string(LittleEndianBytes && input) noexcept : binary_data_{ std::move(input) }
 {
 }
 
@@ -82,7 +82,7 @@ hex_string::from(bytes_view<ByteNumbering> const input) -> hex_string
 {
     if constexpr (ByteNumbering == ByteNumbering::Msb0)
     {
-        return hex_string{ bytes_le_t{ input } };
+        return hex_string{ LittleEndianBytes{ input } };
     }
     else if constexpr (ByteNumbering == ByteNumbering::Lsb0)
     {
@@ -166,7 +166,7 @@ hex_string::swap(hex_string & rhs) noexcept -> void
 template <ByteNumbering ByteNumberingV>
     requires(ByteNumberingV == ByteNumbering::Lsb0)
 constexpr auto
-hex_string::bytes() const -> abc::Bytes<ByteNumberingV> const &
+hex_string::bytes() const -> abc::BasicBytes<ByteNumberingV> const &
 {
     return binary_data_;
 }
@@ -175,9 +175,9 @@ hex_string::bytes() const -> abc::Bytes<ByteNumberingV> const &
 template <ByteNumbering ByteNumberingV>
     requires(ByteNumberingV == ByteNumbering::Msb0)
 constexpr auto
-hex_string::bytes() const -> abc::Bytes<ByteNumberingV>
+hex_string::bytes() const -> abc::BasicBytes<ByteNumberingV>
 {
-    return abc::Bytes<ByteNumberingV>{ static_cast<bytes_le_view_t>(binary_data_) };
+    return abc::BasicBytes<ByteNumberingV>{ static_cast<bytes_le_view_t>(binary_data_) };
 }
 
 constexpr auto
@@ -193,25 +193,25 @@ hex_string::operator[](size_t const index) const noexcept -> const_reference
 }
 
 constexpr auto
-hex_string::least_significant_byte() const noexcept -> byte
+hex_string::least_significant_byte() const noexcept -> byte_t
 {
     return binary_data_.front();
 }
 
 constexpr auto
-hex_string::least_significant_byte() noexcept -> byte &
+hex_string::least_significant_byte() noexcept -> byte_t &
 {
     return binary_data_.front();
 }
 
 constexpr auto
-hex_string::most_significant_byte() const noexcept -> byte
+hex_string::most_significant_byte() const noexcept -> byte_t
 {
     return binary_data_.back();
 }
 
 constexpr auto
-hex_string::most_significant_byte() noexcept -> byte &
+hex_string::most_significant_byte() noexcept -> byte_t &
 {
     return binary_data_.back();
 }

--- a/include/abc/hex_string_decl.h
+++ b/include/abc/hex_string_decl.h
@@ -36,12 +36,12 @@ public:
     constexpr static auto upper_case = hex_string_format::upper_case;
 
 private:
-    bytes_le_t binary_data_;
+    LittleEndianBytes binary_data_;
 
 public:
     hex_string() = default;
 
-    constexpr explicit hex_string(bytes_le_t && input) noexcept;
+    constexpr explicit hex_string(LittleEndianBytes && input) noexcept;
 
     constexpr explicit hex_string(bytes_le_view_t input) noexcept;
 
@@ -81,7 +81,7 @@ public:
     static auto from(std::string_view input) -> expected<hex_string, std::error_code>;
 
     /// @brief construct hex_string object from a byte buffer view.
-    /// @tparam ByteNumbering specify the byte numbering of the input Bytes.
+    /// @tparam ByteNumbering specify the byte numbering of the input BasicBytes.
     /// @param input input byte buffer.
     /// @return the constructed hex_string object.
     template <ByteNumbering ByteNumbering>
@@ -101,7 +101,7 @@ public:
     /// @return true if the hex string is empty, otherwise false.
     [[nodiscard]] constexpr auto empty() const noexcept -> bool;
 
-    /// @brief get the size of the hex string in Bytes.
+    /// @brief get the size of the hex string in BasicBytes.
     /// @return the byte size of the hex string.
     [[nodiscard]] constexpr auto bytes_size() const noexcept -> size_t;
 
@@ -119,12 +119,12 @@ public:
     /// @brief get the byte buffer of the hex string in little endian format.
     template <ByteNumbering ByteNumbering>
         requires(ByteNumbering == ByteNumbering::Lsb0)
-    [[nodiscard]] constexpr auto bytes() const -> abc::Bytes<ByteNumbering> const &;
+    [[nodiscard]] constexpr auto bytes() const -> abc::BasicBytes<ByteNumbering> const &;
 
     /// @brief get the byte buffer of the hex string in big endian format.
     template <ByteNumbering ByteNumbering>
         requires(ByteNumbering == ByteNumbering::Msb0)
-    constexpr auto bytes() const -> abc::Bytes<ByteNumbering>;
+    constexpr auto bytes() const -> abc::BasicBytes<ByteNumbering>;
 
     /// @brief get the modifiable nibble at the specified index.
     /// @param index the nibble index.
@@ -138,19 +138,19 @@ public:
 
     /// @brief get the least significant byte.
     /// @return the byte value of the least significant byte.
-    [[nodiscard]] constexpr auto least_significant_byte() const noexcept -> byte;
+    [[nodiscard]] constexpr auto least_significant_byte() const noexcept -> byte_t;
 
     /// @brief get the least significant byte.
     /// @return the byte reference of the least significant byte.
-    [[nodiscard]] constexpr auto least_significant_byte() noexcept -> byte &;
+    [[nodiscard]] constexpr auto least_significant_byte() noexcept -> byte_t &;
 
     /// @brief get the most significant byte.
     /// @return the byte value of the most significant byte.
-    [[nodiscard]] constexpr auto most_significant_byte() const noexcept -> byte;
+    [[nodiscard]] constexpr auto most_significant_byte() const noexcept -> byte_t;
 
     /// @brief get the most significant byte.
     /// @return the byte reference of the most significant byte.
-    [[nodiscard]] constexpr auto most_significant_byte() noexcept -> byte &;
+    [[nodiscard]] constexpr auto most_significant_byte() noexcept -> byte_t &;
 };
 
 } // namespace abc

--- a/include/abc/hex_utility.h
+++ b/include/abc/hex_utility.h
@@ -10,8 +10,8 @@
 #include <abc/error.h>
 #include <abc/expected.h>
 
-#include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/algorithm/all_of.hpp>
+#include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/view/chunk.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/reverse.hpp>
@@ -36,17 +36,14 @@ public:
     constexpr static auto prefix_0X = "0X";
 
 #if defined(ABC_CXX23)
-    constexpr static std::bitset<256> const hex_flag
-    {
-        "00000000000000000000000000000000"
-        "00000000000000000000000000000000"
-        "00000000000000000000000000000000"
-        "00000000000000000000000000000000"
-        "00000000000000000000000001111110"  // abcdef
-        "00000000000000000000000001111110"  // ABCDEF
-        "00000011111111110000000000000000"  // 0123456789
-        "00000000000000000000000000000000"
-    };
+    constexpr static std::bitset<256> const hex_flag{ "00000000000000000000000000000000"
+                                                      "00000000000000000000000000000000"
+                                                      "00000000000000000000000000000000"
+                                                      "00000000000000000000000000000000"
+                                                      "00000000000000000000000001111110" // abcdef
+                                                      "00000000000000000000000001111110" // ABCDEF
+                                                      "00000011111111110000000000000000" // 0123456789
+                                                      "00000000000000000000000000000000" };
 #else
     static std::bitset<256> const hex_flag;
 #endif
@@ -95,11 +92,8 @@ public:
 
     [[nodiscard]] constexpr static auto
     is_hex_without_prefix(std::string_view const string_slice) noexcept -> bool
-    {   // "0123456789abcdefABCDEF"
-        return ranges::all_of(string_slice,
-                              [](auto const ch) {
-                                  return is_hex(ch);
-                              });
+    { // "0123456789abcdefABCDEF"
+        return ranges::all_of(string_slice, [](auto const ch) { return is_hex(ch); });
     }
 
     [[nodiscard]] constexpr static auto
@@ -113,10 +107,8 @@ public:
         return is_hex_without_prefix(string_slice.substr(2));
     }
 
-    [[nodiscard]] static auto
-    hex_char_to_binary(char ch) noexcept -> abc::expected<byte, std::error_code>;
-
+    [[nodiscard]] static auto hex_char_to_binary(char ch) noexcept -> abc::expected<byte_t, std::error_code>;
 };
-}
+} // namespace abc
 
 #endif

--- a/include/abc/memory.h
+++ b/include/abc/memory.h
@@ -52,31 +52,31 @@ aligned_size(std::size_t size, std::size_t alignment) noexcept -> std::size_t
 
 template <std::size_t Alignment>
 inline auto
-address_aligned_at(byte * ptr) noexcept -> byte *
+address_aligned_at(byte_t * ptr) noexcept -> byte_t *
 {
     static_assert(std::has_single_bit(Alignment), "Alignment must be a power of 2");
-    return reinterpret_cast<byte *>((reinterpret_cast<std::uintptr_t>(ptr) + (Alignment - 1)) & -Alignment);
+    return reinterpret_cast<byte_t *>((reinterpret_cast<std::uintptr_t>(ptr) + (Alignment - 1)) & -Alignment);
 }
 
 template <typename T>
 inline auto
-address_aligned_at(byte * ptr) noexcept -> T *
+address_aligned_at(byte_t * ptr) noexcept -> T *
 {
     return reinterpret_cast<T *>(address_aligned_at<alignof(T)>(ptr));
 }
 
 inline auto
-address_aligned_at(std::size_t alignment, byte * ptr) noexcept -> byte *
+address_aligned_at(std::size_t alignment, byte_t * ptr) noexcept -> byte_t *
 {
     assert(std::has_single_bit(alignment));
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4146)
     // warning C4146: unary minus operator applied to unsigned type, result still unsigned
-    return reinterpret_cast<byte *>((reinterpret_cast<std::uintptr_t>(ptr) + (alignment - 1)) & -alignment);
+    return reinterpret_cast<byte_t *>((reinterpret_cast<std::uintptr_t>(ptr) + (alignment - 1)) & -alignment);
 #pragma warning(pop)
 #else
-    return reinterpret_cast<byte *>((reinterpret_cast<std::uintptr_t>(ptr) + (alignment - 1)) & -alignment);
+    return reinterpret_cast<byte_t *>((reinterpret_cast<std::uintptr_t>(ptr) + (alignment - 1)) & -alignment);
 #endif
 }
 
@@ -100,12 +100,12 @@ public:
     {
     }
 
-    constexpr explicit observer_ptr(pointer_type ptr) noexcept : ptr_{ptr}
+    constexpr explicit observer_ptr(pointer_type ptr) noexcept : ptr_{ ptr }
     {
     }
 
     template <typename U, typename = typename std::enable_if_t<std::is_convertible<typename std::add_pointer<U>::type, pointer_type>::value>>
-    constexpr observer_ptr(observer_ptr<U> p) noexcept : ptr_{p.get()}
+    constexpr observer_ptr(observer_ptr<U> p) noexcept : ptr_{ p.get() }
     {
     }
 

--- a/include/abc/uint128.h
+++ b/include/abc/uint128.h
@@ -122,7 +122,7 @@ public:
             }
             else
             {
-                byte * dst = reinterpret_cast<byte *>(&ret);
+                auto * dst = reinterpret_cast<byte_t *>(&ret);
                 dst += (sizeof(uint128_t) - bytes.size());
                 std::memcpy(dst, bytes.data(), bytes.size());
             }
@@ -151,7 +151,7 @@ public:
             if constexpr (ByteNumberingV == ByteNumbering::Msb0)
             {
                 uint128_t ret;
-                byte * dst = reinterpret_cast<byte *>(&ret);
+                auto * dst = reinterpret_cast<byte_t *>(&ret);
 
                 ranges::copy(bytes | ranges::views::reverse, dst);
                 return ret;
@@ -165,7 +165,7 @@ public:
             if constexpr (ByteNumberingV == ByteNumbering::Lsb0)
             {
                 uint128_t ret;
-                byte * dst = reinterpret_cast<byte *>(&ret);
+                auto * dst = reinterpret_cast<byte_t *>(&ret);
                 dst += sizeof(uint128_t);
 
                 ranges::copy_backward(bytes | ranges::views::reverse, dst);
@@ -175,7 +175,7 @@ public:
             if constexpr (ByteNumberingV == ByteNumbering::Msb0)
             {
                 uint128_t ret;
-                byte * dst = reinterpret_cast<byte *>(&ret);
+                auto * dst = reinterpret_cast<byte_t *>(&ret);
                 dst += (sizeof(uint128_t) - bytes.size());
                 std::memcpy(dst, bytes.data(), bytes.size());
                 return ret;
@@ -342,7 +342,7 @@ public:
 
     template <abc::ByteNumbering ByteNumberingV>
     constexpr void
-    export_bits(Bytes<ByteNumberingV> & ret) const
+    export_bits(BasicBytes<ByteNumberingV> & ret) const
     {
         if constexpr (ByteNumberingV == ByteNumbering::Msb0)
         {
@@ -372,9 +372,9 @@ public:
 
     template <abc::ByteNumbering ByteNumberingV>
     [[nodiscard]] constexpr auto
-    export_bits() const noexcept -> Bytes<ByteNumberingV>
+    export_bits() const noexcept -> BasicBytes<ByteNumberingV>
     {
-        Bytes<ByteNumberingV> ret;
+        BasicBytes<ByteNumberingV> ret;
         ret.reserve(16);
         export_bits(ret);
         return ret;
@@ -389,7 +389,7 @@ public:
 
     template <abc::ByteNumbering ByteNumberingV>
     void
-    export_bits_compact(Bytes<ByteNumberingV> & ret) const noexcept
+    export_bits_compact(BasicBytes<ByteNumberingV> & ret) const noexcept
     {
         auto leading_zeros_bits_count = std::countl_zero(this->upper_);
         if (leading_zeros_bits_count == 64)
@@ -413,9 +413,9 @@ public:
 
     template <abc::ByteNumbering ByteNumberingV>
     [[nodiscard]] constexpr auto
-    export_bits_compact() const -> Bytes<ByteNumberingV>
+    export_bits_compact() const -> BasicBytes<ByteNumberingV>
     {
-        Bytes<ByteNumberingV> ret;
+        BasicBytes<ByteNumberingV> ret;
         ret.reserve(16);
         export_bits_compact(ret);
 
@@ -902,7 +902,7 @@ private:
 
     template <abc::ByteNumbering ByteNumberingV>
     constexpr static void
-    convert_to_bytes(uint64_t const val, Bytes<ByteNumberingV> & ret)
+    convert_to_bytes(uint64_t const val, BasicBytes<ByteNumberingV> & ret)
     {
         static_assert(ByteNumberingV == abc::ByteNumbering::Lsb0 || ByteNumberingV == abc::ByteNumbering::Msb0);
 
@@ -937,7 +937,7 @@ private:
 
     template <abc::ByteNumbering ByteNumberingV>
     constexpr static void
-    convert_to_bytes(uint64_t const value, std::size_t leading_zero_bytes_count, Bytes<ByteNumberingV> & ret)
+    convert_to_bytes(uint64_t const value, std::size_t leading_zero_bytes_count, BasicBytes<ByteNumberingV> & ret)
     {
         static_assert(ByteNumberingV == abc::ByteNumbering::Lsb0 || ByteNumberingV == abc::ByteNumbering::Msb0);
 

--- a/src/hex_string.cpp
+++ b/src/hex_string.cpp
@@ -12,7 +12,7 @@ namespace abc
 /// @return bytes object or an error code object.
 template <ByteNumbering ByteNumberingV>
 static auto
-to_bytes(std::string_view string_slice) -> expected<Bytes<ByteNumberingV>, std::error_code>
+to_bytes(std::string_view string_slice) -> expected<BasicBytes<ByteNumberingV>, std::error_code>
 {
     static_assert(ByteNumberingV == abc::ByteNumbering::Lsb0 || ByteNumberingV == abc::ByteNumbering::Msb0);
 
@@ -26,7 +26,7 @@ to_bytes(std::string_view string_slice) -> expected<Bytes<ByteNumberingV>, std::
         return make_unexpected(make_error_code(std::errc::invalid_argument));
     }
 
-    abc::Bytes<ByteNumberingV> binary_data;
+    abc::BasicBytes<ByteNumberingV> binary_data;
     binary_data.reserve((string_slice.size() + 1) / 2);
     if constexpr (ByteNumberingV == ByteNumbering::Msb0)
     {
@@ -41,7 +41,7 @@ to_bytes(std::string_view string_slice) -> expected<Bytes<ByteNumberingV>, std::
 
         auto const & chunks = string_slice | ranges::views::chunk(2);
         ranges::for_each(chunks, [&binary_data](ranges::viewable_range auto && compound_byte) mutable {
-            byte byte{};
+            byte_t byte{};
             for (auto const [i, nibble_byte] : compound_byte | ranges::views::reverse | ranges::views::enumerate)
             {
                 byte |= hex_char_to_binary(nibble_byte).value() << (4 * i);
@@ -65,7 +65,7 @@ to_bytes(std::string_view string_slice) -> expected<Bytes<ByteNumberingV>, std::
 
         auto const & chunks = string_slice | ranges::views::chunk(2);
         ranges::for_each(chunks, [&binary_data](ranges::viewable_range auto && compound_byte) mutable {
-            byte byte{};
+            byte_t byte{};
             for (auto const [i, nibble_byte] : compound_byte | ranges::views::reverse | ranges::views::enumerate)
             {
                 byte |= hex_utility::hex_char_to_binary(nibble_byte).value() << (4 * i);

--- a/src/hex_utility.cpp
+++ b/src/hex_utility.cpp
@@ -3,36 +3,39 @@
 
 #include <abc/hex_utility.h>
 
-namespace abc {
+namespace abc
+{
 
 #if !defined(ABC_CXX23)
-std::bitset<256> const hex_utility::hex_flag
-{
-    "00000000000000000000000000000000"
-    "00000000000000000000000000000000"
-    "00000000000000000000000000000000"
-    "00000000000000000000000000000000"
-    "00000000000000000000000001111110"  // abcdef
-    "00000000000000000000000001111110"  // ABCDEF
-    "00000011111111110000000000000000"  // 0123456789
-    "00000000000000000000000000000000"
-};
+std::bitset<256> const hex_utility::hex_flag{ "00000000000000000000000000000000"
+                                              "00000000000000000000000000000000"
+                                              "00000000000000000000000000000000"
+                                              "00000000000000000000000000000000"
+                                              "00000000000000000000000001111110" // abcdef
+                                              "00000000000000000000000001111110" // ABCDEF
+                                              "00000011111111110000000000000000" // 0123456789
+                                              "00000000000000000000000000000000" };
 #endif
 
-auto hex_utility::hex_char_to_binary(char const ch) noexcept -> abc::expected<byte, std::error_code> {
-    if ('0' <= ch && ch <= '9') {
-        return static_cast<byte>(ch - '0');
+auto
+hex_utility::hex_char_to_binary(char const ch) noexcept -> abc::expected<byte_t, std::error_code>
+{
+    if ('0' <= ch && ch <= '9')
+    {
+        return static_cast<byte_t>(ch - '0');
     }
 
-    if ('a' <= ch && ch <= 'f') {
-        return static_cast<byte>(ch - 'a' + 10);
+    if ('a' <= ch && ch <= 'f')
+    {
+        return static_cast<byte_t>(ch - 'a' + 10);
     }
 
-    if ('A' <= ch && ch <= 'F') {
-        return static_cast<byte>(ch - 'A' + 10);
+    if ('A' <= ch && ch <= 'F')
+    {
+        return static_cast<byte_t>(ch - 'A' + 10);
     }
 
     return make_unexpected(make_error_code(std::errc::invalid_argument));
 }
 
-}
+} // namespace abc

--- a/tests/bytes.cpp
+++ b/tests/bytes.cpp
@@ -13,7 +13,7 @@ using namespace abc;
 TEST(xbytes_endian_t, constructor_il)
 {
     {
-        bytes_msb0_t bytes = bytes_be_t::from<ByteNumbering::Msb0>({ 0x01, 0x02, 0x03, 0x04 });
+        Msb0Bytes bytes = BigEndianBytes::from<ByteNumbering::Msb0>({ 0x01, 0x02, 0x03, 0x04 });
         EXPECT_EQ(bytes[0], 0x01);
         EXPECT_EQ(bytes[1], 0x02);
         EXPECT_EQ(bytes[2], 0x03);
@@ -21,8 +21,8 @@ TEST(xbytes_endian_t, constructor_il)
     }
 
     {
-        bytes_msb0_t bytes{ 0x01, 0x02, 0x03, 0x04 };
-        bytes_msb0_t bytes2{ bytes };
+        Msb0Bytes bytes{ 0x01, 0x02, 0x03, 0x04 };
+        Msb0Bytes bytes2{ bytes };
         EXPECT_EQ(bytes2[0], 0x01);
         EXPECT_EQ(bytes2[1], 0x02);
         EXPECT_EQ(bytes2[2], 0x03);
@@ -30,8 +30,8 @@ TEST(xbytes_endian_t, constructor_il)
     }
 
     {
-        bytes_msb0_t bytes{ 0x01, 0x02, 0x03, 0x04 };
-        bytes_msb0_t bytes2{ std::move(bytes) };
+        Msb0Bytes bytes{ 0x01, 0x02, 0x03, 0x04 };
+        Msb0Bytes bytes2{ std::move(bytes) };
         EXPECT_EQ(bytes2[0], 0x01);
         EXPECT_EQ(bytes2[1], 0x02);
         EXPECT_EQ(bytes2[2], 0x03);
@@ -39,7 +39,7 @@ TEST(xbytes_endian_t, constructor_il)
     }
 
     {
-        bytes_lsb0_t bytes{ 0x01, 0x02, 0x03, 0x04 };
+        Lsb0Bytes bytes{ 0x01, 0x02, 0x03, 0x04 };
         EXPECT_EQ(bytes[0], 0x01);
         EXPECT_EQ(bytes[1], 0x02);
         EXPECT_EQ(bytes[2], 0x03);
@@ -47,16 +47,16 @@ TEST(xbytes_endian_t, constructor_il)
     }
 
     {
-        bytes_lsb0_t bytes{ 0x01, 0x02, 0x03, 0x04 };
-        bytes_lsb0_t bytes2{ bytes };
+        Lsb0Bytes bytes{ 0x01, 0x02, 0x03, 0x04 };
+        Lsb0Bytes bytes2{ bytes };
         EXPECT_EQ(bytes2[0], 0x01);
         EXPECT_EQ(bytes2[1], 0x02);
         EXPECT_EQ(bytes2[2], 0x03);
         EXPECT_EQ(bytes2[3], 0x04);
     }
     {
-        bytes_lsb0_t bytes{ 0x01, 0x02, 0x03, 0x04 };
-        bytes_lsb0_t bytes2{ std::move(bytes) };
+        Lsb0Bytes bytes{ 0x01, 0x02, 0x03, 0x04 };
+        Lsb0Bytes bytes2{ std::move(bytes) };
         EXPECT_EQ(bytes2[0], 0x01);
         EXPECT_EQ(bytes2[1], 0x02);
         EXPECT_EQ(bytes2[2], 0x03);
@@ -67,20 +67,20 @@ TEST(xbytes_endian_t, constructor_il)
 TEST(xbytes_endian_t, construct_uint)
 {
     {
-        bytes_msb0_t bytes = bytes_msb0_t::from(0x0102u);
+        Msb0Bytes bytes = Msb0Bytes::from(0x0102u);
         EXPECT_EQ(bytes[0], 0x01);
         EXPECT_EQ(bytes[1], 0x02);
         EXPECT_EQ(bytes.size(), 2);
     }
     {
-        bytes_msb0_t bytes = bytes_msb0_t::from(0x010203u);
+        Msb0Bytes bytes = Msb0Bytes::from(0x010203u);
         EXPECT_EQ(bytes[0], 0x01);
         EXPECT_EQ(bytes[1], 0x02);
         EXPECT_EQ(bytes[2], 0x03);
         EXPECT_EQ(bytes.size(), 3);
     }
     {
-        bytes_msb0_t bytes = bytes_msb0_t::from(0x01020304u);
+        Msb0Bytes bytes = Msb0Bytes::from(0x01020304u);
         EXPECT_EQ(bytes[0], 0x01);
         EXPECT_EQ(bytes[1], 0x02);
         EXPECT_EQ(bytes[2], 0x03);
@@ -88,25 +88,25 @@ TEST(xbytes_endian_t, construct_uint)
         EXPECT_EQ(bytes.size(), 4);
     }
     {
-        bytes_lsb0_t bytes = bytes_lsb0_t::from(0x01u);
+        Lsb0Bytes bytes = Lsb0Bytes::from(0x01u);
         EXPECT_EQ(bytes[0], 0x01);
         EXPECT_EQ(bytes.size(), 1);
     }
     {
-        bytes_lsb0_t bytes = bytes_lsb0_t::from(0x0102u);
+        Lsb0Bytes bytes = Lsb0Bytes::from(0x0102u);
         EXPECT_EQ(bytes[0], 0x02);
         EXPECT_EQ(bytes[1], 0x01);
         EXPECT_EQ(bytes.size(), 2);
     }
     {
-        bytes_lsb0_t bytes = bytes_lsb0_t::from(0x010203u);
+        Lsb0Bytes bytes = Lsb0Bytes::from(0x010203u);
         EXPECT_EQ(bytes[0], 0x03);
         EXPECT_EQ(bytes[1], 0x02);
         EXPECT_EQ(bytes[2], 0x01);
         EXPECT_EQ(bytes.size(), 3);
     }
     {
-        bytes_lsb0_t bytes = bytes_lsb0_t::from(0x01020304u);
+        Lsb0Bytes bytes = Lsb0Bytes::from(0x01020304u);
         EXPECT_EQ(bytes[0], 0x04);
         EXPECT_EQ(bytes[1], 0x03);
         EXPECT_EQ(bytes[2], 0x02);
@@ -114,7 +114,7 @@ TEST(xbytes_endian_t, construct_uint)
         EXPECT_EQ(bytes.size(), 4);
     }
     {
-        bytes_msb0_t bytes = bytes_msb0_t::from(0x0102030405060708u);
+        Msb0Bytes bytes = Msb0Bytes::from(0x0102030405060708u);
         EXPECT_EQ(bytes[0], 0x01);
         EXPECT_EQ(bytes[1], 0x02);
         EXPECT_EQ(bytes[2], 0x03);
@@ -126,7 +126,7 @@ TEST(xbytes_endian_t, construct_uint)
         EXPECT_EQ(bytes.size(), 8);
     }
     {
-        bytes_lsb0_t bytes = bytes_lsb0_t::from(0x0102030405060708u);
+        Lsb0Bytes bytes = Lsb0Bytes::from(0x0102030405060708u);
         EXPECT_EQ(bytes[0], 0x08);
         EXPECT_EQ(bytes[1], 0x07);
         EXPECT_EQ(bytes[2], 0x06);
@@ -141,7 +141,7 @@ TEST(xbytes_endian_t, construct_uint)
 
 TEST(bytes_endian_t, from_negtive_int)
 {
-    bytes_lsb0_t bytes = bytes_lsb0_t::from(-1);
+    Lsb0Bytes bytes = Lsb0Bytes::from(-1);
     EXPECT_EQ(bytes[0], 0xff);
     EXPECT_EQ(bytes[1], 0xff);
     EXPECT_EQ(bytes[2], 0xff);
@@ -152,8 +152,8 @@ TEST(bytes_endian_t, from_negtive_int)
 TEST(bytes, operator_plus_bytes)
 {
     {
-        bytes_be_t lhs = bytes_be_t::from(0x1234567890);
-        bytes_be_t rhs = bytes_be_t::from(0x0987654321);
+        BigEndianBytes lhs = BigEndianBytes::from(0x1234567890);
+        BigEndianBytes rhs = BigEndianBytes::from(0x0987654321);
 
         lhs = lhs + rhs;
         ASSERT_EQ(abc::hex_string::from("0x12345678900987654321").transform([](auto const & hex_string) { return hex_string.template bytes<abc::ByteNumbering::Msb0>(); }).value(),
@@ -161,8 +161,8 @@ TEST(bytes, operator_plus_bytes)
     }
 
     {
-        bytes_be_t lhs = bytes_be_t::from(0x1234567890);
-        bytes_be_t rhs = bytes_be_t::from(0x0987654321);
+        BigEndianBytes lhs = BigEndianBytes::from(0x1234567890);
+        BigEndianBytes rhs = BigEndianBytes::from(0x0987654321);
 
         void const * lhs_ptr = std::addressof(lhs);
         lhs += rhs;
@@ -175,17 +175,17 @@ TEST(bytes, operator_plus_bytes)
 TEST(bytes, operator_plus_byte_after)
 {
     {
-        bytes_be_t lhs = bytes_be_t::from(0x1234567890);
+        BigEndianBytes lhs = BigEndianBytes::from(0x1234567890);
 
-        lhs = lhs + static_cast<abc::byte>(0);
+        lhs = lhs + static_cast<abc::byte_t>(0);
         ASSERT_EQ(abc::hex_string::from("0x123456789000").transform([](auto const & hex_string) { return hex_string.template bytes<abc::ByteNumbering::Msb0>(); }).value(), lhs);
     }
 
     {
-        bytes_be_t lhs = bytes_be_t::from(0x1234567890);
+        BigEndianBytes lhs = BigEndianBytes::from(0x1234567890);
 
         void const * lhs_ptr = std::addressof(lhs);
-        lhs += static_cast<abc::byte>(0);
+        lhs += static_cast<abc::byte_t>(0);
         ASSERT_EQ(abc::hex_string::from("0x123456789000").transform([](auto const & hex_string) { return hex_string.template bytes<abc::ByteNumbering::Msb0>(); }).value(), lhs);
         ASSERT_EQ(lhs_ptr, std::addressof(lhs));
     }
@@ -193,16 +193,16 @@ TEST(bytes, operator_plus_byte_after)
 
 TEST(bytes, operator_plus_byte_before)
 {
-    bytes_be_t lhs = bytes_be_t::from(0x1234567890);
+    BigEndianBytes lhs = BigEndianBytes::from(0x1234567890);
 
-    lhs = static_cast<abc::byte>(1) + lhs.view();
+    lhs = static_cast<abc::byte_t>(1) + lhs.view();
     ASSERT_EQ(abc::hex_string::from("0x11234567890").transform([](auto const & hex_string) { return hex_string.template bytes<abc::ByteNumbering::Msb0>(); }).value(), lhs);
 }
 
 TEST(bytes, operator_plus_view)
 {
-    bytes_be_t lhs{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
-    bytes_be_t bytes{ 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
+    BigEndianBytes lhs{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+    BigEndianBytes bytes{ 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
 
     lhs = lhs + bytes_be_view_t{ bytes };
 
@@ -215,7 +215,7 @@ TEST(bytes, operator_plus_view)
 TEST(bytes, to)
 {
     {
-        bytes_be_t bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        BigEndianBytes bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
         auto bytes_le = bytes_be.to<ByteNumbering::Lsb0>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(bytes_be.size()); ++i)
         {
@@ -224,7 +224,7 @@ TEST(bytes, to)
     }
 
     {
-        auto bytes_le = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::Lsb0>();
+        auto bytes_le = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::Lsb0>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(8); ++i)
         {
             ASSERT_EQ(i, bytes_le[8 - i - 1]);
@@ -232,7 +232,7 @@ TEST(bytes, to)
     }
 
     {
-        bytes_be_t bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        BigEndianBytes bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
         auto bytes = bytes_be.to<ByteNumbering::None>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(bytes_be.size()); ++i)
         {
@@ -241,7 +241,7 @@ TEST(bytes, to)
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::None>();
+        auto bytes = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::None>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(8); ++i)
         {
             ASSERT_EQ(i, bytes[i]);
@@ -249,7 +249,7 @@ TEST(bytes, to)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
         auto bytes_be = bytes_le.to<ByteNumbering::Msb0>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(bytes_le.size()); ++i)
         {
@@ -258,7 +258,7 @@ TEST(bytes, to)
     }
 
     {
-        auto bytes_be = bytes_le_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::Msb0>();
+        auto bytes_be = LittleEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::Msb0>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(8); ++i)
         {
             ASSERT_EQ(i, bytes_be[8 - i - 1]);
@@ -266,7 +266,7 @@ TEST(bytes, to)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
         auto bytes = bytes_le.to<ByteNumbering::None>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(bytes_le.size()); ++i)
         {
@@ -275,7 +275,7 @@ TEST(bytes, to)
     }
 
     {
-        auto bytes = bytes_le_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::None>();
+        auto bytes = LittleEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::None>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(8); ++i)
         {
             ASSERT_EQ(i, bytes[i]);
@@ -283,7 +283,7 @@ TEST(bytes, to)
     }
 
     {
-        bytes_t bytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        Bytes bytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
         auto bytes_be = bytes.to<ByteNumbering::Msb0>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(bytes.size()); ++i)
         {
@@ -292,7 +292,7 @@ TEST(bytes, to)
     }
 
     {
-        auto bytes_be = bytes_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::Msb0>();
+        auto bytes_be = Bytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::Msb0>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(8); ++i)
         {
             ASSERT_EQ(i, bytes_be[i]);
@@ -300,7 +300,7 @@ TEST(bytes, to)
     }
 
     {
-        bytes_t bytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        Bytes bytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
         auto bytes_le = bytes.to<ByteNumbering::Lsb0>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(bytes.size()); ++i)
         {
@@ -309,7 +309,7 @@ TEST(bytes, to)
     }
 
     {
-        auto bytes_le = bytes_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::Lsb0>();
+        auto bytes_le = Bytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 }.to<ByteNumbering::Lsb0>();
         for (uint8_t i = 0u; i < static_cast<uint8_t>(8); ++i)
         {
             ASSERT_EQ(i, bytes_le[i]);
@@ -320,17 +320,17 @@ TEST(bytes, to)
 TEST(bytes, from_bytes_view)
 {
     {
-        bytes_be_t bytes_be_src = bytes_be_t::from(0x01020304);
+        BigEndianBytes bytes_be_src = BigEndianBytes::from(0x01020304);
         bytes_be_view_t bytes_be_view = bytes_be_src;
 
-        auto bytes = bytes_be_t::from(bytes_be_view);
+        auto bytes = BigEndianBytes::from(bytes_be_view);
         ASSERT_EQ(bytes_be_src, bytes);
     }
 
     {
-        bytes_t src = abc::bytes_t::from(0x01020304);
+        Bytes src = abc::Bytes::from(0x01020304);
         bytes_view_t view = src;
-        auto bytes = bytes_be_t::from(view);
+        auto bytes = BigEndianBytes::from(view);
 
         ASSERT_EQ(bytes[0], 0x04);
         ASSERT_EQ(bytes[1], 0x03);
@@ -342,55 +342,55 @@ TEST(bytes, from_bytes_view)
 TEST(bytes, to_int)
 {
     {
-        bytes_be_t bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        BigEndianBytes bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
         auto u64 = bytes_be.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x01020304050607);
     }
 
     {
-        bytes_be_t bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x00 };
+        BigEndianBytes bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x00 };
         auto u64 = bytes_be.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x01020304050600);
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
+        auto bytes = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x010203040506);
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00 };
+        auto bytes = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x010203040500);
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
+        auto bytes = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x0102030405);
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
+        auto bytes = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x0102030400);
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04 };
+        auto bytes = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x01020304);
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x00 };
+        auto bytes = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x01020300);
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01, 0x02, 0x03 };
+        auto bytes = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x010203);
         auto u32 = bytes.to<std::uint32_t>();
@@ -398,7 +398,7 @@ TEST(bytes, to_int)
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01, 0x02, 0x00 };
+        auto bytes = BigEndianBytes{ 0x00, 0x01, 0x02, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x010200);
         auto u32 = bytes.to<std::uint32_t>();
@@ -406,7 +406,7 @@ TEST(bytes, to_int)
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01, 0x02 };
+        auto bytes = BigEndianBytes{ 0x00, 0x01, 0x02 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x0102);
         auto u32 = bytes.to<std::uint32_t>();
@@ -414,7 +414,7 @@ TEST(bytes, to_int)
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01, 0x00 };
+        auto bytes = BigEndianBytes{ 0x00, 0x01, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x0100);
         auto u32 = bytes.to<std::uint32_t>();
@@ -422,7 +422,7 @@ TEST(bytes, to_int)
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x01 };
+        auto bytes = BigEndianBytes{ 0x00, 0x01 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x01);
         auto u32 = bytes.to<std::uint32_t>();
@@ -432,7 +432,7 @@ TEST(bytes, to_int)
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00, 0x00 };
+        auto bytes = BigEndianBytes{ 0x00, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x00);
         auto u32 = bytes.to<std::uint32_t>();
@@ -442,7 +442,7 @@ TEST(bytes, to_int)
     }
 
     {
-        auto bytes = bytes_be_t{ 0x01 };
+        auto bytes = BigEndianBytes{ 0x01 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x01);
         auto u32 = bytes.to<std::uint32_t>();
@@ -454,7 +454,7 @@ TEST(bytes, to_int)
     }
 
     {
-        auto bytes = bytes_be_t{ 0x00 };
+        auto bytes = BigEndianBytes{ 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x00);
         auto u32 = bytes.to<std::uint32_t>();
@@ -466,55 +466,55 @@ TEST(bytes, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
         auto u64 = bytes_le.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x0706050403020100);
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x00 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x00 };
         auto u64 = bytes_le.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x06050403020100);
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
         auto u64 = bytes_le.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x06050403020100);
     }
 
     {
-        auto bytes = bytes_le_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00 };
+        auto bytes = LittleEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x050403020100);
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
         auto u64 = bytes_le.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x050403020100);
     }
 
     {
-        auto bytes = bytes_le_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
+        auto bytes = LittleEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x0403020100);
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04 };
         auto u64 = bytes_le.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x0403020100);
     }
 
     {
-        auto bytes = bytes_le_t{ 0x00, 0x01, 0x02, 0x03, 0x00 };
+        auto bytes = LittleEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x03020100);
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03 };
         auto u64 = bytes_le.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x03020100);
         auto u32 = bytes_le.to<std::uint32_t>();
@@ -522,7 +522,7 @@ TEST(bytes, to_int)
     }
 
     {
-        auto bytes = bytes_le_t{ 0x00, 0x01, 0x02, 0x00 };
+        auto bytes = LittleEndianBytes{ 0x00, 0x01, 0x02, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x020100);
         auto u32 = bytes.to<std::uint32_t>();
@@ -530,7 +530,7 @@ TEST(bytes, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02 };
         auto u64 = bytes_le.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x020100);
         auto u32 = bytes_le.to<std::uint32_t>();
@@ -538,7 +538,7 @@ TEST(bytes, to_int)
     }
 
     {
-        auto bytes = bytes_le_t{ 0x00, 0x01, 0x00 };
+        auto bytes = LittleEndianBytes{ 0x00, 0x01, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x0100);
         auto u32 = bytes.to<std::uint32_t>();
@@ -546,7 +546,7 @@ TEST(bytes, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01 };
         auto u64 = bytes_le.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x0100);
         auto u32 = bytes_le.to<std::uint32_t>();
@@ -556,7 +556,7 @@ TEST(bytes, to_int)
     }
 
     {
-        auto bytes = bytes_le_t{ 0x00, 0x00 };
+        auto bytes = LittleEndianBytes{ 0x00, 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x00);
         auto u32 = bytes.to<std::uint32_t>();
@@ -566,7 +566,7 @@ TEST(bytes, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x01 };
+        LittleEndianBytes bytes_le{ 0x01 };
         auto u64 = bytes_le.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x01);
         auto u32 = bytes_le.to<std::uint32_t>();
@@ -578,7 +578,7 @@ TEST(bytes, to_int)
     }
 
     {
-        auto bytes = bytes_le_t{ 0x00 };
+        auto bytes = LittleEndianBytes{ 0x00 };
         auto u64 = bytes.to<std::uint64_t>();
         ASSERT_EQ(u64, 0x00);
         auto u32 = bytes.to<std::uint32_t>();
@@ -593,8 +593,8 @@ TEST(bytes, to_int)
 TEST(bytes, assign_from_view)
 {
     {
-        bytes_be_t bytes_be{ 0x00, 0x01, 0x02, 0x03 };
-        bytes_be_t const bytes_be_expected{ 0x04, 0x05, 0x06, 0x07 };
+        BigEndianBytes bytes_be{ 0x00, 0x01, 0x02, 0x03 };
+        BigEndianBytes const bytes_be_expected{ 0x04, 0x05, 0x06, 0x07 };
         bytes_be_view_t bytes_be_view{ bytes_be_expected };
 
         bytes_be = bytes_be_view;
@@ -602,8 +602,8 @@ TEST(bytes, assign_from_view)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03 };
-        bytes_le_t const bytes_le_expected{ 0x04, 0x05, 0x06, 0x07 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03 };
+        LittleEndianBytes const bytes_le_expected{ 0x04, 0x05, 0x06, 0x07 };
         bytes_le_view_t bytes_le_view{ bytes_le_expected };
 
         bytes_le = bytes_le_view;
@@ -611,8 +611,8 @@ TEST(bytes, assign_from_view)
     }
 
     {
-        bytes_t bytes{ 0x00, 0x01, 0x02, 0x03 };
-        bytes_t const bytes_expected{ 0x04, 0x05, 0x06, 0x07 };
+        Bytes bytes{ 0x00, 0x01, 0x02, 0x03 };
+        Bytes const bytes_expected{ 0x04, 0x05, 0x06, 0x07 };
         bytes_view_t bytes_view{ bytes_expected };
 
         bytes = bytes_view;
@@ -623,8 +623,8 @@ TEST(bytes, assign_from_view)
 TEST(bytes, from_string_view)
 {
     {
-        auto bytes = bytes_t::from("01020304");
-        
+        auto bytes = Bytes::from("01020304");
+
         ASSERT_EQ(bytes.size(), 8);
 
         ASSERT_EQ(bytes[0], '0');

--- a/tests/bytes_view.cpp
+++ b/tests/bytes_view.cpp
@@ -11,7 +11,7 @@ TEST(bytes_view, bytes)
     using namespace abc;
 
     {
-        bytes_be_t bytes_be{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be{ 'a', 'b', 'c', 'd' };
         bytes_be_view_t bytes_be_view = bytes_be.view();
 
         ASSERT_EQ(bytes_be.size(), bytes_be_view.size());
@@ -22,7 +22,7 @@ TEST(bytes_view, bytes)
     }
 
     {
-        bytes_be_t bytes_be{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be{ 'a', 'b', 'c', 'd' };
         auto bytes_be_view = static_cast<bytes_be_view_t>(bytes_be);
 
         ASSERT_EQ(bytes_be.size(), bytes_be_view.size());
@@ -33,7 +33,7 @@ TEST(bytes_view, bytes)
     }
 
     {
-        bytes_be_t bytes_be{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be{ 'a', 'b', 'c', 'd' };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         ASSERT_EQ(bytes_be.size(), bytes_be_view.size());
@@ -44,8 +44,8 @@ TEST(bytes_view, bytes)
     }
 
     {
-        bytes_be_t bytes_be{ 'a', 'b', 'c', 'd' };
-        bytes_be_view_t bytes_be_view = bytes_be_view_t::from(bytes_be.data(), bytes_be.size(), ByteNumberingType<bytes_be_t::byte_numbering_v>{});
+        BigEndianBytes bytes_be{ 'a', 'b', 'c', 'd' };
+        bytes_be_view_t bytes_be_view = bytes_be_view_t::from(bytes_be.data(), bytes_be.size(), ByteNumberingType<BigEndianBytes::byte_numbering_v>{});
 
         ASSERT_EQ(bytes_be.size(), bytes_be_view.size());
         ASSERT_EQ('a', bytes_be_view[0]);
@@ -55,7 +55,7 @@ TEST(bytes_view, bytes)
     }
 
     {
-        bytes_be_t bytes_be{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be{ 'a', 'b', 'c', 'd' };
         bytes_be_view_t bytes_be_view = bytes_be_view_t::from(bytes_be.data(), 2, ByteNumberingType<ByteNumbering::Msb0>{});
 
         ASSERT_EQ(2, bytes_be_view.size());
@@ -64,7 +64,7 @@ TEST(bytes_view, bytes)
     }
 
     {
-        bytes_be_t bytes_be{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be{ 'a', 'b', 'c', 'd' };
         bytes_be_view_t bytes_be_view{ bytes_be.last(2) };
 
         ASSERT_EQ(2, bytes_be_view.size());
@@ -107,7 +107,7 @@ TEST(bytes_view, to_int)
 {
     using namespace abc;
     {
-        bytes_be_t bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        BigEndianBytes bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -115,7 +115,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        bytes_be_t bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x00 };
+        BigEndianBytes bytes_be{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x00 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -123,7 +123,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -131,7 +131,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -139,7 +139,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -147,7 +147,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -155,7 +155,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x04 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -163,7 +163,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x01, 0x02, 0x03, 0x00 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x00 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -171,7 +171,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x01, 0x02, 0x03 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x01, 0x02, 0x03 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -181,7 +181,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x01, 0x02, 0x00 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x01, 0x02, 0x00 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -191,7 +191,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x01, 0x02 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x01, 0x02 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -201,7 +201,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x01, 0x00 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x01, 0x00 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -211,7 +211,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x01 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x01 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -223,7 +223,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00, 0x00 };
+        auto bytes_be = BigEndianBytes{ 0x00, 0x00 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -235,7 +235,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x01 };
+        auto bytes_be = BigEndianBytes{ 0x01 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -249,7 +249,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_be = bytes_be_t{ 0x00 };
+        auto bytes_be = BigEndianBytes{ 0x00 };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         auto u64 = bytes_be_view.to<std::uint64_t>();
@@ -263,7 +263,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -271,7 +271,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x00 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x00 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -279,7 +279,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -287,7 +287,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_le = bytes_le_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00 };
+        auto bytes_le = LittleEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -295,7 +295,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -303,7 +303,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_le = bytes_le_t{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
+        auto bytes_le = LittleEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -311,7 +311,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03, 0x04 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -319,7 +319,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_le = bytes_le_t{ 0x00, 0x01, 0x02, 0x03, 0x00 };
+        auto bytes_le = LittleEndianBytes{ 0x00, 0x01, 0x02, 0x03, 0x00 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -327,7 +327,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02, 0x03 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02, 0x03 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -337,7 +337,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_le = bytes_le_t{ 0x00, 0x01, 0x02, 0x00 };
+        auto bytes_le = LittleEndianBytes{ 0x00, 0x01, 0x02, 0x00 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -347,7 +347,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01, 0x02 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01, 0x02 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -357,7 +357,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_le = bytes_le_t{ 0x00, 0x01, 0x00 };
+        auto bytes_le = LittleEndianBytes{ 0x00, 0x01, 0x00 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -367,7 +367,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x00, 0x01 };
+        LittleEndianBytes bytes_le{ 0x00, 0x01 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -379,7 +379,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_le = bytes_le_t{ 0x00, 0x00 };
+        auto bytes_le = LittleEndianBytes{ 0x00, 0x00 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -391,7 +391,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        bytes_le_t bytes_le{ 0x01 };
+        LittleEndianBytes bytes_le{ 0x01 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -405,7 +405,7 @@ TEST(bytes_view, to_int)
     }
 
     {
-        auto bytes_le = bytes_le_t{ 0x00 };
+        auto bytes_le = LittleEndianBytes{ 0x00 };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         auto u64 = bytes_le_view.to<std::uint64_t>();
@@ -424,7 +424,7 @@ TEST(bytes_be_view, operator_equal_equal)
     using namespace abc;
 
     {
-        bytes_be_t bytes_be{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be{ 'a', 'b', 'c', 'd' };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         ASSERT_TRUE(bytes_be_view == bytes_be_view);
@@ -432,7 +432,7 @@ TEST(bytes_be_view, operator_equal_equal)
     }
 
     {
-        bytes_be_t bytes_be{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be{ 'a', 'b', 'c', 'd' };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         ASSERT_TRUE(bytes_be_view == bytes_be);
@@ -440,7 +440,7 @@ TEST(bytes_be_view, operator_equal_equal)
     }
 
     {
-        bytes_be_t bytes_be{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be{ 'a', 'b', 'c', 'd' };
         bytes_be_view_t bytes_be_view{ bytes_be };
 
         ASSERT_TRUE(bytes_be == bytes_be_view);
@@ -448,8 +448,8 @@ TEST(bytes_be_view, operator_equal_equal)
     }
 
     {
-        bytes_be_t bytes_be1{ 'a', 'b', 'c', 'd' };
-        bytes_be_t bytes_be2{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be1{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be2{ 'a', 'b', 'c', 'd' };
         bytes_be_view_t bytes_be_view1{ bytes_be1 };
         bytes_be_view_t bytes_be_view2{ bytes_be2 };
 
@@ -458,8 +458,8 @@ TEST(bytes_be_view, operator_equal_equal)
     }
 
     {
-        bytes_be_t bytes_be1{ 'a', 'b', 'c', 'd' };
-        bytes_be_t bytes_be2{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be1{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be2{ 'a', 'b', 'c', 'd' };
         bytes_be_view_t bytes_be_view1{ bytes_be1 };
         bytes_be_view_t bytes_be_view2{ bytes_be2 };
 
@@ -470,8 +470,8 @@ TEST(bytes_be_view, operator_equal_equal)
     }
 
     {
-        bytes_be_t bytes_be1{ 'a', 'b', 'c', 'd' };
-        bytes_be_t bytes_be2{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be1{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be2{ 'a', 'b', 'c', 'd' };
         bytes_be_view_t bytes_be_view1{ bytes_be1 };
         bytes_be_view_t bytes_be_view2{ bytes_be2 };
 
@@ -482,8 +482,8 @@ TEST(bytes_be_view, operator_equal_equal)
     }
 
     {
-        bytes_be_t bytes_be1{ 'a', 'b', 'c', 'd' };
-        bytes_be_t bytes_be2{ 'd', 'c', 'b', 'a' };
+        BigEndianBytes bytes_be1{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be2{ 'd', 'c', 'b', 'a' };
         bytes_be_view_t bytes_be_view1{ bytes_be1 };
         bytes_be_view_t bytes_be_view2{ bytes_be2 };
 
@@ -493,8 +493,8 @@ TEST(bytes_be_view, operator_equal_equal)
     }
 
     {
-        bytes_be_t bytes_be1{ 'a', 'b', 'c', 'd' };
-        bytes_be_t bytes_be2{ 'd', 'c', 'b', 'a' };
+        BigEndianBytes bytes_be1{ 'a', 'b', 'c', 'd' };
+        BigEndianBytes bytes_be2{ 'd', 'c', 'b', 'a' };
         bytes_be_view_t bytes_be_view1{ bytes_be1 };
         bytes_be_view_t bytes_be_view2{ bytes_be2 };
 
@@ -510,7 +510,7 @@ TEST(bytes_le_view, operator_equal_equal)
     using namespace abc;
 
     {
-        bytes_le_t bytes_le{ 'a', 'b', 'c', 'd' };
+        LittleEndianBytes bytes_le{ 'a', 'b', 'c', 'd' };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         ASSERT_TRUE(bytes_le_view == bytes_le_view);
@@ -518,7 +518,7 @@ TEST(bytes_le_view, operator_equal_equal)
     }
 
     {
-        bytes_le_t bytes_le{ 'a', 'b', 'c', 'd' };
+        LittleEndianBytes bytes_le{ 'a', 'b', 'c', 'd' };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         ASSERT_TRUE(bytes_le_view == bytes_le);
@@ -526,7 +526,7 @@ TEST(bytes_le_view, operator_equal_equal)
     }
 
     {
-        bytes_le_t bytes_le{ 'a', 'b', 'c', 'd' };
+        LittleEndianBytes bytes_le{ 'a', 'b', 'c', 'd' };
         bytes_le_view_t bytes_le_view{ bytes_le };
 
         ASSERT_TRUE(bytes_le == bytes_le_view);
@@ -534,8 +534,8 @@ TEST(bytes_le_view, operator_equal_equal)
     }
 
     {
-        bytes_le_t bytes_le1{ 'a', 'b', 'c', 'd' };
-        bytes_le_t bytes_le2{ 'a', 'b', 'c', 'd' };
+        LittleEndianBytes bytes_le1{ 'a', 'b', 'c', 'd' };
+        LittleEndianBytes bytes_le2{ 'a', 'b', 'c', 'd' };
         bytes_le_view_t bytes_le_view1{ bytes_le1 };
         bytes_le_view_t bytes_le_view2{ bytes_le2 };
 
@@ -544,8 +544,8 @@ TEST(bytes_le_view, operator_equal_equal)
     }
 
     {
-        bytes_le_t bytes_le1{ 'a', 'b', 'c', 'd' };
-        bytes_le_t bytes_le2{ 'a', 'b', 'c', 'd' };
+        LittleEndianBytes bytes_le1{ 'a', 'b', 'c', 'd' };
+        LittleEndianBytes bytes_le2{ 'a', 'b', 'c', 'd' };
         bytes_le_view_t bytes_le_view1{ bytes_le1 };
         bytes_le_view_t bytes_le_view2{ bytes_le2 };
 
@@ -556,8 +556,8 @@ TEST(bytes_le_view, operator_equal_equal)
     }
 
     {
-        bytes_le_t bytes_le1{ 'a', 'b', 'c', 'd' };
-        bytes_le_t bytes_le2{ 'a', 'b', 'c', 'd' };
+        LittleEndianBytes bytes_le1{ 'a', 'b', 'c', 'd' };
+        LittleEndianBytes bytes_le2{ 'a', 'b', 'c', 'd' };
         bytes_le_view_t bytes_le_view1{ bytes_le1 };
         bytes_le_view_t bytes_le_view2{ bytes_le2 };
 
@@ -568,8 +568,8 @@ TEST(bytes_le_view, operator_equal_equal)
     }
 
     {
-        bytes_le_t bytes_le1{ 'a', 'b', 'c', 'd' };
-        bytes_le_t bytes_le2{ 'd', 'c', 'b', 'a' };
+        LittleEndianBytes bytes_le1{ 'a', 'b', 'c', 'd' };
+        LittleEndianBytes bytes_le2{ 'd', 'c', 'b', 'a' };
         bytes_le_view_t bytes_le_view1{ bytes_le1 };
         bytes_le_view_t bytes_le_view2{ bytes_le2 };
 
@@ -579,8 +579,8 @@ TEST(bytes_le_view, operator_equal_equal)
     }
 
     {
-        bytes_le_t bytes_le1{ 'a', 'b', 'c', 'd' };
-        bytes_le_t bytes_le2{ 'd', 'c', 'b', 'a' };
+        LittleEndianBytes bytes_le1{ 'a', 'b', 'c', 'd' };
+        LittleEndianBytes bytes_le2{ 'd', 'c', 'b', 'a' };
         bytes_le_view_t bytes_le_view1{ bytes_le1 };
         bytes_le_view_t bytes_le_view2{ bytes_le2 };
 

--- a/tests/converters.cpp
+++ b/tests/converters.cpp
@@ -20,7 +20,7 @@ TEST(converters, hex_string_to_fixed_bytes)
 TEST(converters, uint128_to_bytes)
 {
     abc::uint128_t value = abc::hex_string::from("0x1234567890abcdef1234567890abcdef").transform([](auto && hex_string) { return abc::uint128_t::from(hex_string); }).value();
-    abc::bytes_be_t bytes = value.export_bits<abc::ByteNumbering::Msb0>();
+    abc::BigEndianBytes bytes = value.export_bits<abc::ByteNumbering::Msb0>();
     ASSERT_EQ(16, bytes.size());
 
     EXPECT_EQ(0x12, bytes[0]);

--- a/tests/expected.cpp
+++ b/tests/expected.cpp
@@ -874,7 +874,7 @@ namespace wrapper
 {
 template <std::endian Endian>
 constexpr auto
-hex_string_to_binary(std::string_view string_slice) -> abc::expected<abc::Bytes<abc::EndianType<Endian>::byte_numbering_v>, abc::errc>
+hex_string_to_binary(std::string_view string_slice) -> abc::expected<abc::BasicBytes<abc::EndianType<Endian>::byte_numbering_v>, abc::errc>
 {
     if (abc::hex_utility::has_hex_prefix(string_slice))
     {
@@ -886,7 +886,7 @@ hex_string_to_binary(std::string_view string_slice) -> abc::expected<abc::Bytes<
         return abc::unexpected{ abc::errc::invalid_hex_char };
     }
 
-    abc::Bytes<abc::EndianType<Endian>::byte_numbering_v> binary_data;
+    abc::BasicBytes<abc::EndianType<Endian>::byte_numbering_v> binary_data;
     binary_data.reserve((string_slice.size() + 1) / 2);
     if constexpr (Endian == std::endian::big)
     {
@@ -901,7 +901,7 @@ hex_string_to_binary(std::string_view string_slice) -> abc::expected<abc::Bytes<
 
         auto const & chunks = string_slice | ranges::views::chunk(2);
         ranges::for_each(chunks, [&binary_data](ranges::viewable_range auto && compound_byte) mutable {
-            abc::byte byte{};
+            abc::byte_t byte{};
             for (auto const [i, nibble_byte] : compound_byte | ranges::views::reverse | ranges::views::enumerate)
             {
                 byte |= abc::hex_utility::hex_char_to_binary(nibble_byte).value() << (4 * i);
@@ -925,7 +925,7 @@ hex_string_to_binary(std::string_view string_slice) -> abc::expected<abc::Bytes<
 
         auto const & chunks = string_slice | ranges::views::reverse | ranges::views::chunk(2);
         ranges::for_each(chunks, [&binary_data](ranges::viewable_range auto && compound_byte) mutable {
-            abc::byte byte{};
+            abc::byte_t byte{};
             for (auto const [i, nibble_byte] : compound_byte | ranges::views::enumerate)
             {
                 byte |= hex_char_to_binary(nibble_byte).value() << (4 * i);

--- a/tests/fixed_bytes.cpp
+++ b/tests/fixed_bytes.cpp
@@ -54,7 +54,7 @@ TEST(fixed_bytes, move_constructor)
 TEST(fixed_bytes_msb0, from_msb0)
 {
     bytes16_msb0_t bytes{
-        bytes16_msb0_t::from<ByteNumbering::Msb0>(std::array<byte, 16>{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f }).value()
+        bytes16_msb0_t::from<ByteNumbering::Msb0>(std::array<byte_t, 16>{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f }).value()
     };
     EXPECT_EQ(bytes.size(), 16);
     EXPECT_EQ(bytes[0], 0);
@@ -64,7 +64,7 @@ TEST(fixed_bytes_msb0, from_msb0)
 TEST(fixed_bytes_msb0, from_lsb0)
 {
     bytes16_msb0_t bytes{
-        bytes16_msb0_t::from<ByteNumbering::Lsb0>(std::array<byte, 16>{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f }).value()
+        bytes16_msb0_t::from<ByteNumbering::Lsb0>(std::array<byte_t, 16>{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f }).value()
     };
     EXPECT_EQ(bytes.size(), 16);
     EXPECT_EQ(bytes[0], 0x0f);
@@ -73,7 +73,7 @@ TEST(fixed_bytes_msb0, from_lsb0)
 
 TEST(fixed_bytes, array_constructor)
 {
-    std::array<byte, 16> const arr{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    std::array<byte_t, 16> const arr{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
     bytes16_msb0_t bytes = bytes16_msb0_t::from<ByteNumbering::Msb0>(arr).value();
     EXPECT_EQ(bytes.size(), 16);
     for (auto i : std::views::iota(1u, 16u))
@@ -122,7 +122,7 @@ TEST(fixed_bytes_be, from)
 
 TEST(fixed_bytes_le, to)
 {
-    bytes16_lsb0_t bytes{ bytes16_lsb0_t::from<ByteNumbering::Lsb0>(std::array<byte, 16>{ 8, 7, 6, 5, 4, 3, 2, 1 }).value() };
+    bytes16_lsb0_t bytes{ bytes16_lsb0_t::from<ByteNumbering::Lsb0>(std::array<byte_t, 16>{ 8, 7, 6, 5, 4, 3, 2, 1 }).value() };
     EXPECT_EQ(bytes.to<uint64_t>(), 0x0102030405060708U);
     EXPECT_EQ(bytes.to<uint32_t>(), 0x05060708U);
     EXPECT_EQ(bytes.to<uint16_t>(), 0x0708U);
@@ -131,7 +131,7 @@ TEST(fixed_bytes_le, to)
 
 TEST(fixed_bytes_be, to)
 {
-    bytes16_msb0_t bytes{ bytes16_msb0_t::from<ByteNumbering::Msb0>(std::array<byte, 16>{ 1, 2, 3, 4, 5, 6, 7, 8 }).value() }; // 0x01020304050607080000000000000000
+    bytes16_msb0_t bytes{ bytes16_msb0_t::from<ByteNumbering::Msb0>(std::array<byte_t, 16>{ 1, 2, 3, 4, 5, 6, 7, 8 }).value() }; // 0x01020304050607080000000000000000
     EXPECT_EQ(bytes.to<uint64_t>(), 0x00);
     EXPECT_EQ(bytes.to<uint32_t>(), 0x00);
     EXPECT_EQ(bytes.to<uint16_t>(), 0x00);
@@ -197,11 +197,11 @@ TEST(fixed_bytes_le, hex_string)
 //     auto result = fixed_bytes<5, ByteNumbering::none>::from<ByteNumbering::msb0>(bytes);
 //     EXPECT_TRUE(result.has_value());
 ////    auto const & fixed_bytes = result.value();
-////    EXPECT_EQ(static_cast<byte>(0x12), fixed_bytes[0]);
-////    EXPECT_EQ(static_cast<byte>(0x34), fixed_bytes[1]);
-////    EXPECT_EQ(static_cast<byte>(0x56), fixed_bytes[2]);
-////    EXPECT_EQ(static_cast<byte>(0x78), fixed_bytes[3]);
-////    EXPECT_EQ(static_cast<byte>(0x90), fixed_bytes[4]);
+////    EXPECT_EQ(static_cast<byte_t>(0x12), fixed_bytes[0]);
+////    EXPECT_EQ(static_cast<byte_t>(0x34), fixed_bytes[1]);
+////    EXPECT_EQ(static_cast<byte_t>(0x56), fixed_bytes[2]);
+////    EXPECT_EQ(static_cast<byte_t>(0x78), fixed_bytes[3]);
+////    EXPECT_EQ(static_cast<byte_t>(0x90), fixed_bytes[4]);
 //}
 
 TEST(fixed_bytes, subbytes)

--- a/tests/hex_string.cpp
+++ b/tests/hex_string.cpp
@@ -19,7 +19,7 @@ TEST(hex_string, from_string_view)
     ASSERT_EQ(hex_string1.size(), hex_string1.length());
     ASSERT_EQ(hex_string1.size(), 22);
     ASSERT_EQ(hex_string1.bytes_size(), 11);
-    ASSERT_EQ(hex_string1.bytes<ByteNumbering::Msb0>(), (bytes_be_t{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef }));
+    ASSERT_EQ(hex_string1.bytes<ByteNumbering::Msb0>(), (BigEndianBytes{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef }));
 
     auto const hex_string2 = hex_string::from("0x0123456789abcdefabcdef").value();
     ASSERT_EQ(std::strong_ordering::equal, hex_string1 <=> hex_string2);
@@ -32,12 +32,12 @@ TEST(hex_string, from_string_view)
     ASSERT_EQ(hex_string3.size(), hex_string3.length());
     ASSERT_EQ(hex_string3.size(), 22);
     ASSERT_EQ(hex_string3.bytes_size(), 11);
-    ASSERT_EQ(hex_string3.bytes<ByteNumbering::Msb0>(), (bytes_be_t{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef }));
+    ASSERT_EQ(hex_string3.bytes<ByteNumbering::Msb0>(), (BigEndianBytes{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef }));
 }
 
 TEST(hex_string, from_bytes)
 {
-    bytes_be_t const bytes{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10 };
+    BigEndianBytes const bytes{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10 };
     auto const hex_string4 = hex_string::from<abc::ByteNumbering::Msb0>(bytes);
     ASSERT_FALSE(hex_string4.empty());
     ASSERT_EQ(hex_string4.to_string(), "0x0102030405060708090a0b0c0d0e0f10");
@@ -51,7 +51,7 @@ TEST(hex_string, from_bytes)
 
 TEST(hex_string, from_bytes_zero)
 {
-    bytes_be_t const bytes{ 0x00, 0x00 };
+    BigEndianBytes const bytes{ 0x00, 0x00 };
     auto const hex_string4 = hex_string::from<ByteNumbering::Msb0>(bytes);
     ASSERT_FALSE(hex_string4.empty());
     ASSERT_EQ(hex_string4.to_string(), "0x0000");
@@ -65,7 +65,7 @@ TEST(hex_string, from_bytes_zero)
 
 TEST(hex_string, from_empty)
 {
-    bytes_le_t const bytes{};
+    LittleEndianBytes const bytes{};
     auto const hex_string4 = hex_string::from<ByteNumbering::Lsb0>(bytes);
     ASSERT_TRUE(hex_string4.empty());
     ASSERT_EQ(hex_string4.to_string(), "0x00");
@@ -143,7 +143,7 @@ TEST(hex_string, from)
     ASSERT_EQ(hex_string1.size(), hex_string1.length());
     ASSERT_EQ(hex_string1.size(), 22);
     ASSERT_EQ(hex_string1.bytes_size(), 11);
-    ASSERT_EQ(hex_string1.bytes<ByteNumbering::Msb0>(), (bytes_be_t{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef }));
+    ASSERT_EQ(hex_string1.bytes<ByteNumbering::Msb0>(), (BigEndianBytes{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef }));
 }
 
 TEST(hex_string, from_invalid)

--- a/tests/hex_utility.cpp
+++ b/tests/hex_utility.cpp
@@ -130,12 +130,12 @@ TEST(hex_utility, hex_string_to_binary)
 {
     std::random_device rd;
     std::uniform_int_distribution distribution{ 0, 255 };
-    abc::bytes_le_t bytes;
+    abc::LittleEndianBytes bytes;
 
     bytes.resize(std::uniform_int_distribution<size_t>{ 0u, 5000u }(rd));
     for (auto & byte : bytes)
     {
-        byte = static_cast<abc::byte>(distribution(rd));
+        byte = static_cast<abc::byte_t>(distribution(rd));
     }
 
     auto const hex_string = abc::hex_string::from<abc::ByteNumbering::Lsb0>(bytes);

--- a/tests/uint128/functions.cpp
+++ b/tests/uint128/functions.cpp
@@ -50,9 +50,9 @@ TEST(Function, export_bits)
 
     EXPECT_EQ(value, u64);
 
-    abc::bytes_be_t const full{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+    abc::BigEndianBytes const full{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
 
-    abc::bytes_be_t bits;
+    abc::BigEndianBytes bits;
     value.export_bits(bits);
     EXPECT_EQ(bits, full);
 
@@ -67,9 +67,9 @@ TEST(Function, export_bits_compact)
 
     EXPECT_EQ(value, u64);
 
-    abc::bytes_be_t const compact{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+    abc::BigEndianBytes const compact{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
 
-    abc::bytes_be_t bits;
+    abc::BigEndianBytes bits;
     value.export_bits_compact(bits);
     EXPECT_EQ(bits, compact);
 
@@ -84,7 +84,7 @@ TEST(Function, export_bits_compact_zero)
 
     EXPECT_EQ(value, u64);
 
-    abc::bytes_be_t const compact{};
+    abc::BigEndianBytes const compact{};
 
     auto const bits = value.export_bits_compact<abc::ByteNumbering::Msb0>();
     EXPECT_EQ(bits, compact);
@@ -97,12 +97,12 @@ TEST(Function, export_bits_compact_little)
 
     EXPECT_EQ(value, u64);
 
-    abc::bytes_le_t const compact{ 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
+    abc::LittleEndianBytes const compact{ 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
 
     auto const bits = value.export_bits_compact<abc::ByteNumbering::Lsb0>();
     EXPECT_EQ(bits, compact);
 
-    abc::bytes_le_t bits3;
+    abc::LittleEndianBytes bits3;
     bits3.reserve(32);
     value.export_bits_compact(bits3);
     EXPECT_EQ(bits3, compact);
@@ -115,12 +115,12 @@ TEST(Function, export_bits_compact_zero_little)
 
     EXPECT_EQ(value, u64);
 
-    abc::bytes_le_t const compact{};
+    abc::LittleEndianBytes const compact{};
 
     auto const bits = value.export_bits_compact<abc::ByteNumbering::Lsb0>();
     EXPECT_EQ(bits, compact);
 
-    abc::bytes_le_t bits3;
+    abc::LittleEndianBytes bits3;
     bits3.reserve(32);
     value.export_bits_compact(bits3);
     EXPECT_EQ(bits3, compact);


### PR DESCRIPTION
…y. Rename `byte` to `byte_t` and update related classes, including `Bytes` to `BasicBytes`, across the codebase. Adjust unit tests and type traits to reflect these changes, ensuring proper functionality and adherence to the new naming convention.